### PR TITLE
Add `--output-dir` functionality

### DIFF
--- a/lib/metanorma/ribose/processor.rb
+++ b/lib/metanorma/ribose/processor.rb
@@ -19,10 +19,6 @@ module Metanorma
         "Metanorma::Ribose #{Metanorma::Ribose::VERSION}"
       end
 
-      def input_to_isodoc(file, filename)
-        Metanorma::Input::Asciidoc.new.process(file, filename, @asciidoctor_backend)
-      end
-
       def output(isodoc_node, inname, outname, format, options={})
         case format
         when :html


### PR DESCRIPTION
move the Metanorma::Ribose::Processor#input_to_isodoc method to Metanorma::Processor
metanorma/metanorma-cli#134