### PR TITLE
separate anchor for human-supplied or term-name-calculated ids, from …

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,2 +1,2 @@
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "features/termsource-to-source"
-gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/termsource-to-source"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/anchor"

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,2 +1,4 @@
 gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
+gem "metanorma-utils", git: "https://github.com/metanorma/metanorma-utils", branch: "main"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/anchor"
+gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "features/anchor"

--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,4 +1,4 @@
-gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "main"
+gem "isodoc", git: "https://github.com/metanorma/isodoc", branch: "features/anchor"
 gem "metanorma-utils", git: "https://github.com/metanorma/metanorma-utils", branch: "main"
 gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "features/anchor"
 gem "metanorma-generic", git: "https://github.com/metanorma/metanorma-generic", branch: "features/anchor"

--- a/lib/metanorma/ribose/converter.rb
+++ b/lib/metanorma/ribose/converter.rb
@@ -3,9 +3,6 @@ require "metanorma/generic/converter"
 
 module Metanorma
   module Ribose
-    # A {Converter} implementation that generates RSD output, and a document
-    # schema encapsulation of the document for validation
-    #
     class Converter < Metanorma::Generic::Converter
       register_for "ribose"
 
@@ -49,8 +46,7 @@ module Metanorma
       end
 
       def pdf_converter(node)
-        return nil if node.attr("no-pdf")
-
+        node.attr("no-pdf") and return nil
         IsoDoc::Ribose::PdfConvert.new(pdf_extract_attributes(node))
       end
 

--- a/lib/metanorma/ribose/isodoc.rng
+++ b/lib/metanorma/ribose/isodoc.rng
@@ -687,6 +687,20 @@ titlecase, or lowercase</a:documentation>
       </attribute>
     </optional>
   </define>
+  <define name="RequiredId" combine="interleave">
+    <optional>
+      <attribute name="anchor">
+        <a:documentation> User-supplied anchor of element; replaced by content-based id, with all references to the anchor updated accordingly</a:documentation>
+      </attribute>
+    </optional>
+  </define>
+  <define name="OptionalId" combine="interleave">
+    <optional>
+      <attribute name="anchor">
+        <a:documentation> User-supplied anchor of element; replaced by content-based id, with all references to the anchor updated accordingly</a:documentation>
+      </attribute>
+    </optional>
+  </define>
   <define name="ObligationType">
     <a:documentation>The force of a clause in a standard document: whether it has normative or informative effect</a:documentation>
     <choice>

--- a/spec/metanorma/base_spec.rb
+++ b/spec/metanorma/base_spec.rb
@@ -263,8 +263,8 @@ RSpec.describe Metanorma::Ribose do
            </legal-statement>
            <feedback-statement>
              <clause id="_" obligation="normative">
-               <p id="boilerplate-name" align="left">Fred</p>
-               <p id="boilerplate-address" align="left">10 Jack St<br/>Antarctica<br/><br/>
+               <p id="_" anchor="boilerplate-name" align="left">Fred</p>
+               <p id="_" anchor="boilerplate-address" align="left">10 Jack St<br/>Antarctica<br/><br/>
        me@me.com<br/>
        me.example.com</p>
              </clause>
@@ -496,7 +496,7 @@ RSpec.describe Metanorma::Ribose do
           </foreword>
         </preface>
         <sections>
-          <clause id="_" obligation="normative">
+          <clause id="_" anchor="_section_1" obligation="normative">
             <title>Section 1</title>
           </clause>
         </sections>
@@ -597,7 +597,7 @@ RSpec.describe Metanorma::Ribose do
     output = Xml::C14n.format(<<~"OUTPUT")
         #{@blank_hdr.sub(/<status>/, '<abstract> <p>Abstract</p> </abstract> <status>')}
         <preface>
-          <abstract id='_'>
+          <abstract id='_' anchor="_abstract">
           <title>Abstract</title>
             <p id='_'>Abstract</p>
           </abstract>
@@ -605,15 +605,15 @@ RSpec.describe Metanorma::Ribose do
             <title>Foreword</title>
             <p id='_'>Foreword</p>
           </foreword>
-          <executivesummary id='_' obligation="informative">
+          <executivesummary id='_' anchor="_executive_summary" obligation="informative">
             <title>Executive summary</title>
             <p id='_'>Executive Summary</p>
           </executivesummary>
-          <introduction id='_' obligation='informative'>
+          <introduction id='_' anchor="_introduction" obligation='informative'>
             <title>Introduction</title>
             <p id='_'>Introduction</p>
           </introduction>
-          <clause id='_' obligation='informative'>
+          <clause id='_' anchor="_prefatory" obligation='informative'>
             <title>Prefatory</title>
             <p id='_'>Prefatory</p>
           </clause>

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,7 @@ end
 
 def strip_guid(str)
   str.gsub(%r{ id="_[^"]+"}, ' id="_"')
+    .gsub(%r{ semx-id="[^"]*"}, '')
     .gsub(%r{ target="_[^"]+"}, ' target="_"')
     .gsub(%r{ source="_[^"]+"}, ' source="_"')
     .gsub(%r{<fetched>[^<]+</fetched>}, "<fetched/>")


### PR DESCRIPTION
…id for content ids: https://github.com/metanorma/metanorma-standoc/issues/1007

### Metanorma PR checklist

 - [ ] Breaking changes (list related PRs)
 - [ ] Documentation update required ([create task for this](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] External dependency introduced ([documentation update need](https://github.com/metanorma/metanorma.org/issues/new))
 - [ ] Gem with native library introduced

<!-- Feel free to improve/modify the template https://github.com/metanorma/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
