### PR TITLE
Retain subclause title and honour subclause label in cross-references

### DIFF
--- a/lib/isodoc/ribose/i18n-en.yaml
+++ b/lib/isodoc/ribose/i18n-en.yaml
@@ -1,1 +1,2 @@
 table_of_contents: Contents
+subclause: ""

--- a/lib/isodoc/ribose/xref.rb
+++ b/lib/isodoc/ribose/xref.rb
@@ -21,8 +21,10 @@ module IsoDoc
         end
       end
 
-      # subclauses are not prefixed with "Clause"
-      # retaining subtype for the semantics
+      # subclauses are not prefixed with "Clause" but @labels["subclause"],
+      # which in ribose is "" (but in inheriting flavors/tastes may be
+      # "Subclause"/"Clause"). Retaining subtype for the semantics, and the
+      # title so that xrefstyle=full can render it.
       def section_name_anchors(clause, num, level)
         if clause["type"] == "section"
           xref = labelled_autonum(@labels["section"], num)
@@ -31,9 +33,10 @@ module IsoDoc
             { label:, xref:, elem: @labels["section"],
               title: clause_title(clause), level: level, type: "clause" }
         elsif level > 1
-          #num = semx(clause, num)
+          xref = labelled_autonum(@labels["subclause"], num)
           @anchors[clause["id"]] =
-            { label: num, level: level, xref: num, subtype: "clause" }
+            { label: num, level: level, xref:, subtype: "clause",
+              title: clause_title(clause), elem: @labels["subclause"] }
         else super end
       end
 

--- a/spec/isodoc/html_convert_spec.rb
+++ b/spec/isodoc/html_convert_spec.rb
@@ -1403,4 +1403,27 @@ RSpec.describe IsoDoc::Ribose do
      .sub(%r{<localized-strings>.*</localized-strings>}m, "")))
       .to be_xml_equivalent_to presxml
   end
+
+  it "retains the subclause title for full-style cross-references" do
+    input = <<~INPUT
+      <rsd-standard xmlns="http://riboseinc.com/isoxml" type="semantic">
+        <preface>
+          <foreword id="F"><title>Foreword</title>
+            <p id="P">Bare <xref target="O"/>; full <xref target="O" style="full"/>.</p>
+          </foreword>
+        </preface>
+        <sections>
+          <clause id="M"><title>Parent Clause</title>
+            <clause id="O"><title>My Subclause</title><p id="x">x</p></clause>
+          </clause>
+        </sections>
+      </rsd-standard>
+    INPUT
+    pres = IsoDoc::Ribose::PresentationXMLConvert.new(presxml_options)
+      .convert("test", input, true)
+    para = Nokogiri::XML(pres).tap(&:remove_namespaces!).at("//p[@id='P']")
+    # subclause prefix stays blank (bare number) by default, but xrefstyle=full
+    # now surfaces the subclause title, which the old anchor dropped entirely
+    expect(para.to_xml).to include("My Subclause")
+  end
 end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/68

Bring ribose's `section_name_anchors` into line with ISO's i18n-driven design:
the subclause cross-reference prefix is now driven by the `subclause` i18n label
(blank by default → unchanged bare-number output; overridable to e.g.
"Clause"/"Subclause" via a taste `i18n-dictionary` or a document `:i18nyaml:`),
and the subclause title is retained so `:xrefstyle: full` can render it.
Fixes the root cause of metanorma-pdfa#68 (subclause references dropped the
title, so even xrefstyle=full showed only the number). ISO already behaves this
way and is untouched.

## Test plan
- New spec: full-style cross-reference to a subclause now surfaces its title.
- Existing xref golden-master spec unchanged (bare-number default preserved).
- spec/isodoc (9) + spec/metanorma (23) green.

🤖
