### PR TITLE
Wrap subclause cross-reference titles in <semx element='title'>

### DIFF
--- a/lib/isodoc/ribose/xref.rb
+++ b/lib/isodoc/ribose/xref.rb
@@ -29,14 +29,18 @@ module IsoDoc
         if clause["type"] == "section"
           xref = labelled_autonum(@labels["section"], num)
           label = labelled_autonum(@labels["section"], num)
+          t = clause_title(clause)
           @anchors[clause["id"]] =
             { label:, xref:, elem: @labels["section"],
-              title: clause_title(clause), level: level, type: "clause" }
+              title: t && semx(clause, t, "title"), level: level,
+              type: "clause" }
         elsif level > 1
           xref = labelled_autonum(@labels["subclause"], num)
+          t = clause_title(clause)
           @anchors[clause["id"]] =
             { label: num, level: level, xref:, subtype: "clause",
-              title: clause_title(clause), elem: @labels["subclause"] }
+              title: t && semx(clause, t, "title"),
+              elem: @labels["subclause"] }
         else super end
       end
 

--- a/spec/isodoc/html_convert_spec.rb
+++ b/spec/isodoc/html_convert_spec.rb
@@ -1423,7 +1423,9 @@ RSpec.describe IsoDoc::Ribose do
       .convert("test", input, true)
     para = Nokogiri::XML(pres).tap(&:remove_namespaces!).at("//p[@id='P']")
     # subclause prefix stays blank (bare number) by default, but xrefstyle=full
-    # now surfaces the subclause title, which the old anchor dropped entirely
-    expect(para.to_xml).to include("My Subclause")
+    # now surfaces the subclause title semx-wrapped (metanorma-pdfa#68) — the old
+    # anchor first dropped the title entirely, then emitted it as bare text
+    expect(para.to_xml)
+      .to include('<semx element="title" source="O">My Subclause</semx>')
   end
 end


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/68

Subclause cross-reference titles were stored **bare** on the anchor, where base isodoc stores them **semx-wrapped**. `anchor_xref_full` emits the anchor title verbatim, so `full`/`title`-style cross-references to subclauses dropped the `<semx element="title" source="…">` wrapper that top-level clauses keep — breaking downstream XSLT that keys off `semx[@element='title']`.

Wrap the title in `section_name_anchors` (section and subclause branches), matching base isodoc, guarded so title-less clauses stay `nil`. The existing full-xref regression test is strengthened to assert the wrapper (it previously only checked the title text, which passed for bare text too — the reason this regressed unnoticed).

🤖
