### PR TITLE
Suppress clause delimiter via i18n, not code

### DIFF
--- a/lib/isodoc/ribose/base_convert.rb
+++ b/lib/isodoc/ribose/base_convert.rb
@@ -1,10 +1,6 @@
 module IsoDoc
   module Ribose
     module BaseConvert
-      def clausedelim
-        ""
-      end
-
       def configuration
         Metanorma::Ribose.configuration
       end

--- a/lib/isodoc/ribose/i18n-en.yaml
+++ b/lib/isodoc/ribose/i18n-en.yaml
@@ -1,2 +1,3 @@
 table_of_contents: Contents
 subclause: ""
+clause_delimiter: ""


### PR DESCRIPTION
Refs https://github.com/metanorma/metanorma-pdfa/issues/74

Ribose intended to suppress the terminal clause-number delimiter (`clausedelim` → `""` in `BaseConvert`), but that override only reached the final-format converters (Html/Pdf/Word); `Ribose::PresentationXMLConvert` fell through to the base `"."`, so the period was baked into the presentation XML that the FO/PDF path consumes (metanorma-pdfa#74).

Fix via i18n (single source of truth, no inheritor code): set `clause_delimiter: ''` in the ribose i18n dictionary and drop the now-redundant `BaseConvert#clausedelim` override. The presentation stage honours it, so PDF/FO drops the period too, and downstream users can retune it without XSL tricks.

**Draft / gated:** requires the configurable `clause_delimiter` from metanorma/isodoc#838 (isodoc 3.7.2); inert until that ships.

🤖
