### PR TITLE
Move RiboseDocument model from metanorma-document to metanorma-ribose

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,18 @@
-Encoding.default_external = Encoding::UTF_8
-Encoding.default_internal = Encoding::UTF_8
-
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
+
+# TEMPORARY: cross-PR branch pins so CI can resolve the in-flight
+# metanorma-standoc namespace rename (Metanorma::Standoc::Document)
+# and the pubid-2 / relaton-bib 2.2 / metanorma-document 0.5 chain.
+# Revert each pin once the corresponding PR merges:
+#   - https://github.com/metanorma/metanorma-standoc/pull/1232
+#   - https://github.com/metanorma/metanorma-document/pull/45
+gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/move-standard-document"
+gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
+gem "isodoc", github: "metanorma/isodoc", branch: "rt-pubid-2-migration"
+gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
+gem "pubid", github: "pubid/pubid", branch: "main"
 
 eval_gemfile("Gemfile.devel") rescue nil

--- a/lib/metanorma/ribose.rb
+++ b/lib/metanorma/ribose.rb
@@ -1,4 +1,5 @@
 require "metanorma-core"
+require "metanorma/ribose/document"
 require "metanorma-generic"
 require "metanorma/ribose/processor"
 

--- a/lib/metanorma/ribose/document.rb
+++ b/lib/metanorma/ribose/document.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Forward-declare parent namespace so this file is safe to require
+# directly (without first requiring metanorma/ribose.rb).
+module Metanorma
+  module Ribose
+  end
+end
+
+
+module Metanorma
+  module Ribose::Document
+    autoload :Metadata, "metanorma/ribose/document/metadata"
+    autoload :Root, "metanorma/ribose/document/root"
+  end
+end
+
+# Backwards-compat alias so external consumers that reference
+# Metanorma::RiboseDocument keep resolving during the transition.
+module Metanorma
+  existing = defined?(Metanorma::RiboseDocument) && Metanorma::RiboseDocument
+  if !existing.equal?(Metanorma::Ribose::Document)
+    Metanorma.send(:remove_const, :RiboseDocument) if existing
+    RiboseDocument = Metanorma::Ribose::Document
+  end
+end
+
+if defined?(Metanorma::Registers::Setup.setup_ribose_register)
+  Metanorma::Registers::Setup.setup_ribose_register
+end
+
+module Metanorma
+  deprecate_constant :RiboseDocument
+end

--- a/lib/metanorma/ribose/document/metadata.rb
+++ b/lib/metanorma/ribose/document/metadata.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ribose::Document
+    module Metadata
+      autoload :RiboseBibDataExtensionType,
+               "#{__dir__}/metadata/ribose_bib_data_extension_type"
+      autoload :RiboseBibliographicItem,
+               "#{__dir__}/metadata/ribose_bibliographic_item"
+    end
+  end
+end

--- a/lib/metanorma/ribose/document/metadata/ribose_bib_data_extension_type.rb
+++ b/lib/metanorma/ribose/document/metadata/ribose_bib_data_extension_type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ribose::Document
+    module Metadata
+      # Extension point for bibliographical definitions of Ribose documents.
+      # Inherits all ISO extension fields; adds security and recipient.
+      class RiboseBibDataExtensionType < Metanorma::IsoDocument::Metadata::IsoBibDataExtensionType
+        attribute :security, :string
+        attribute :recipient, :string
+
+        xml do
+          element "ext"
+          map_element "security", to: :security
+          map_element "recipient", to: :recipient
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ribose/document/metadata/ribose_bibliographic_item.rb
+++ b/lib/metanorma/ribose/document/metadata/ribose_bibliographic_item.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ribose::Document
+    module Metadata
+      # Bibliographical description of a Ribose document.
+      # Inherits all ISO bibliographic fields; overrides ext for Ribose format.
+      class RiboseBibliographicItem < Metanorma::IsoDocument::Metadata::IsoBibliographicItem
+        attribute :ext, RiboseBibDataExtensionType
+
+        xml do
+          element "bibdata"
+          map_element "ext", to: :ext
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ribose/document/root.rb
+++ b/lib/metanorma/ribose/document/root.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+module Metanorma
+  module Ribose::Document
+    class Root < Lutaml::Model::Serializable
+      include Metanorma::Standoc::Document::RootAttributes
+
+      attribute :bibdata,
+                Metanorma::Ribose::Document::Metadata::RiboseBibliographicItem
+      attribute :preface,
+                Metanorma::Standoc::Document::Sections::Preface
+      attribute :sections,
+                Metanorma::Standoc::Document::Sections::Sections
+      attribute :annex,
+                Metanorma::Standoc::Document::Sections::AnnexSection,
+                collection: true
+
+      xml do
+        element "metanorma"
+        namespace Metanorma::Standoc::Document::Namespace
+
+        Metanorma::Standoc::Document::RootXmlMapping.apply(self)
+      end
+    end
+  end
+end

--- a/spec/fixtures/ribose/nereon-syntax/rsd-nereon-configuration-syntax.presentation.xml
+++ b/spec/fixtures/ribose/nereon-syntax/rsd-nereon-configuration-syntax.presentation.xml
@@ -1,0 +1,755 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metanorma xmlns="https://www.metanorma.org/ns/standoc" type="presentation" version="2.7.9" schema-version="v2.1.5" flavor="ribose">
+<bibdata type="standard">
+<title language="en" type="main">Configuration management — Nereon configuration model — Object configuration and schema syntax</title>
+<docidentifier primary="true" type="Ribose">XXXXX(d)</docidentifier><docnumber>XXXXX</docnumber><contributor><role type="author"/><organization>
+<name>Ribose Asia Limited</name>
+<abbreviation>Ribose</abbreviation></organization></contributor><contributor><role type="author"><description>committee</description></role><organization>
+<name>Ribose Asia Limited</name>
+<subdivision type="Committee" subtype="technical">
+<name>Configuration management</name>
+</subdivision></organization></contributor><contributor><role type="publisher"/><organization>
+<name>Ribose Asia Limited</name>
+<abbreviation>Ribose</abbreviation></organization></contributor><edition language="">1</edition><edition language="en">first edition</edition><version><revision-date>2018-10-08</revision-date></version><language current="true">en</language><script current="true">Latn</script><status><stage>draft-standard</stage></status><copyright><from>2018</from><owner><organization>
+<name>Ribose Asia Limited</name>
+<abbreviation>Ribose</abbreviation></organization></owner></copyright><ext><doctype>standard</doctype><flavor>ribose</flavor></ext></bibdata><localized-strings><localized-string key="scope" language="en">Scope</localized-string><localized-string key="symbolsabbrev" language="en">Symbols and abbreviated terms</localized-string><localized-string key="abbrev" language="en">Abbreviated terms</localized-string><localized-string key="symbols" language="en">Symbols</localized-string><localized-string key="table_of_contents" language="en">Contents</localized-string><localized-string key="introduction" language="en">Introduction</localized-string><localized-string key="foreword" language="en">Foreword</localized-string><localized-string key="abstract" language="en">Abstract</localized-string><localized-string key="acknowledgements" language="en">Acknowledgements</localized-string><localized-string key="executivesummary" language="en">Executive summary</localized-string><localized-string key="termsdef" language="en">Terms and definitions</localized-string><localized-string key="termsdefsymbolsabbrev" language="en">Terms, definitions, symbols and abbreviated terms</localized-string><localized-string key="termsdefsymbols" language="en">Terms, definitions and symbols</localized-string><localized-string key="termsdefabbrev" language="en">Terms, definitions and abbreviated terms</localized-string><localized-string key="normref" language="en">Normative references</localized-string><localized-string key="bibliography" language="en">Bibliography</localized-string><localized-string key="index" language="en">Index</localized-string><localized-string key="see" language="en">see</localized-string><localized-string key="see_also" language="en">see also</localized-string><localized-string key="preface" language="en">Preface</localized-string><localized-string key="section" language="en">Section</localized-string><localized-string key="clause" language="en">Clause</localized-string><localized-string key="annex" language="en">Annex</localized-string><localized-string key="appendix" language="en">Appendix</localized-string><localized-string key="continued" language="en">continued</localized-string><localized-string key="no_terms_boilerplate" language="en">No terms and definitions are listed in this document.
+</localized-string><localized-string key="internal_terms_boilerplate" language="en">For the purposes of this document, the following terms and definitions apply.
+</localized-string><localized-string key="norm_with_refs_pref" language="en">The following documents are referred to in the text in such a way that some or all of their content constitutes requirements of this document. For dated references, only the edition cited applies. For undated references, the latest edition of the referenced document (including any amendments) applies.</localized-string><localized-string key="norm_empty_pref" language="en">There are no normative references in this document.</localized-string><localized-string key="external_terms_boilerplate" language="en">For the purposes of this document, the terms and definitions given in % apply.
+</localized-string><localized-string key="internal_external_terms_boilerplate" language="en">For the purposes of this document, the terms and definitions given in % and the following apply.
+</localized-string><localized-string key="no_information_available" language="en">[NO INFORMATION AVAILABLE]</localized-string><localized-string key="term_defined_in" language="en">(%)</localized-string><localized-string key="binary_and" language="en">%1 <conn>and</conn> %2</localized-string><localized-string key="multiple_and" language="en">%1<enum-comma>,</enum-comma> <conn>and</conn> %2</localized-string><localized-string key="binary_or" language="en">%1 <conn>or</conn> %2</localized-string><localized-string key="multiple_or" language="en">%1<enum-comma>,</enum-comma> <conn>or</conn> %2</localized-string><localized-string key="chain_and" language="en">%1 <conn>and</conn> %2</localized-string><localized-string key="chain_or" language="en">%1 <conn>or</conn> %2</localized-string><localized-string key="chain_from" language="en">%1 <conn>from</conn> %2</localized-string><localized-string key="chain_to" language="en">%1 <conn>to</conn> %2</localized-string><localized-string key="nested_xref" language="en">%1<comma>,</comma> %2</localized-string><localized-string key="list_nested_xref" language="en">%1 %2</localized-string><localized-string key="SpelloutRules" language="en">spellout-ordinal</localized-string><localized-string key="OrdinalRules" language="en">digits-ordinal</localized-string><localized-string key="note" language="en">NOTE</localized-string><localized-string key="note_xref" language="en">Note</localized-string><localized-string key="termnote" language="en">Note % to entry</localized-string><localized-string key="list" language="en">List</localized-string><localized-string key="deflist" language="en">Definition List</localized-string><localized-string key="figure" language="en">Figure</localized-string><localized-string key="diagram" language="en">Diagram</localized-string><localized-string key="formula" language="en">Formula</localized-string><localized-string key="inequality" language="en">Formula</localized-string><localized-string key="table" language="en">Table</localized-string><localized-string key="requirement" language="en">Requirement</localized-string><localized-string key="recommendation" language="en">Recommendation</localized-string><localized-string key="permission" language="en">Permission</localized-string><localized-string key="box" language="en">Box</localized-string><localized-string key="no_identifier" language="en">(NO ID)</localized-string><localized-string key="recommendationtest" language="en">Recommendation test</localized-string><localized-string key="requirementtest" language="en">Requirement test</localized-string><localized-string key="permissiontest" language="en">Permission test</localized-string><localized-string key="recommendationclass" language="en">Recommendations class</localized-string><localized-string key="requirementclass" language="en">Requirements class</localized-string><localized-string key="permissionclass" language="en">Permissions class</localized-string><localized-string key="abstracttest" language="en">Abstract test</localized-string><localized-string key="conformanceclass" language="en">Conformance class</localized-string><localized-string key="key" language="en">Key</localized-string><localized-string key="example" language="en">EXAMPLE</localized-string><localized-string key="example_xref" language="en">Example</localized-string><localized-string key="where" language="en">where</localized-string><localized-string key="where_one" language="en">where</localized-string><localized-string key="wholeoftext" language="en">Whole of text</localized-string><localized-string key="draft_label" language="en">draft</localized-string><localized-string key="inform_annex" language="en">informative</localized-string><localized-string key="norm_annex" language="en">normative</localized-string><localized-string key="modified" language="en">modified</localized-string><localized-string key="adapted" language="en">adapted</localized-string><localized-string key="deprecated" language="en">DEPRECATED</localized-string><localized-string key="source" language="en">SOURCE</localized-string><localized-string key="and" language="en">and</localized-string><localized-string key="all_parts" language="en">All Parts</localized-string><localized-string key="edition_ordinal" language="en">{{ var1 | ordinal_word: '', '' }} edition</localized-string><localized-string key="edition" language="en">edition</localized-string><localized-string key="version" language="en">version</localized-string><localized-string key="toc_figures" language="en">List of figures</localized-string><localized-string key="toc_tables" language="en">List of tables</localized-string><localized-string key="toc_recommendations" language="en">List of recommendations</localized-string><localized-string key="month_january" language="en">January</localized-string><localized-string key="month_february" language="en">February</localized-string><localized-string key="month_march" language="en">March</localized-string><localized-string key="month_april" language="en">April</localized-string><localized-string key="month_may" language="en">May</localized-string><localized-string key="month_june" language="en">June</localized-string><localized-string key="month_july" language="en">July</localized-string><localized-string key="month_august" language="en">August</localized-string><localized-string key="month_september" language="en">September</localized-string><localized-string key="month_october" language="en">October</localized-string><localized-string key="month_november" language="en">November</localized-string><localized-string key="month_december" language="en">December</localized-string><localized-string key="obligation" language="en">Obligation</localized-string><localized-string key="admonition.danger" language="en">Danger</localized-string><localized-string key="admonition.warning" language="en">Warning</localized-string><localized-string key="admonition.caution" language="en">Caution</localized-string><localized-string key="admonition.important" language="en">Important</localized-string><localized-string key="admonition.safety_precautions" language="en">Safety Precautions</localized-string><localized-string key="admonition.editorial" language="en">Editorial Note</localized-string><localized-string key="locality.section" language="en">Section</localized-string><localized-string key="locality.clause" language="en">Clause</localized-string><localized-string key="locality.part" language="en">Part</localized-string><localized-string key="locality.paragraph" language="en">Paragraph</localized-string><localized-string key="locality.chapter" language="en">Chapter</localized-string><localized-string key="locality.page" language="en">Page</localized-string><localized-string key="locality.table" language="en">Table</localized-string><localized-string key="locality.annex" language="en">Annex</localized-string><localized-string key="locality.figure" language="en">Figure</localized-string><localized-string key="locality.example" language="en">Example</localized-string><localized-string key="locality.note" language="en">Note</localized-string><localized-string key="locality.formula" language="en">Formula</localized-string><localized-string key="grammar_abbrevs.masculine" language="en">m</localized-string><localized-string key="grammar_abbrevs.feminine" language="en">f</localized-string><localized-string key="grammar_abbrevs.neuter" language="en">n</localized-string><localized-string key="grammar_abbrevs.common" language="en">common</localized-string><localized-string key="grammar_abbrevs.singular" language="en">sg</localized-string><localized-string key="grammar_abbrevs.dual" language="en">dual</localized-string><localized-string key="grammar_abbrevs.pl" language="en">pl</localized-string><localized-string key="grammar_abbrevs.isPreposition" language="en">prep</localized-string><localized-string key="grammar_abbrevs.isParticiple" language="en">part</localized-string><localized-string key="grammar_abbrevs.isAdjective" language="en">adj</localized-string><localized-string key="grammar_abbrevs.isAdverb" language="en">adv</localized-string><localized-string key="grammar_abbrevs.isNoun" language="en">noun</localized-string><localized-string key="grammar_abbrevs.isVerb" language="en">verb</localized-string><localized-string key="relatedterms.deprecates" language="en">deprecates</localized-string><localized-string key="relatedterms.supersedes" language="en">supersedes</localized-string><localized-string key="relatedterms.narrower" language="en">narrower</localized-string><localized-string key="relatedterms.broader" language="en">broader</localized-string><localized-string key="relatedterms.equivalent" language="en">equivalent</localized-string><localized-string key="relatedterms.compare" language="en">compare</localized-string><localized-string key="relatedterms.contrast" language="en">contrast</localized-string><localized-string key="relatedterms.see" language="en">see</localized-string><localized-string key="relatedterms.seealso" language="en">see also</localized-string><localized-string key="Clause.sg" language="en">Clause</localized-string><localized-string key="Clause.pl" language="en">Clauses</localized-string><localized-string key="Annex.sg" language="en">Annex</localized-string><localized-string key="Annex.pl" language="en">Annexes</localized-string><localized-string key="Appendix.sg" language="en">Appendix</localized-string><localized-string key="Appendix.pl" language="en">Appendixes</localized-string><localized-string key="Note.sg" language="en">Note</localized-string><localized-string key="Note.pl" language="en">Notes</localized-string><localized-string key="Note_%_to_entry.sg" language="en">Note % to entry</localized-string><localized-string key="Note_%_to_entry.pl" language="en">Notes % to entry</localized-string><localized-string key="List.sg" language="en">List</localized-string><localized-string key="List.pl" language="en">Lists</localized-string><localized-string key="Figure.sg" language="en">Figure</localized-string><localized-string key="Figure.pl" language="en">Figures</localized-string><localized-string key="Formula.sg" language="en">Formula</localized-string><localized-string key="Formula.pl" language="en">Formulas</localized-string><localized-string key="Table.sg" language="en">Table</localized-string><localized-string key="Table.pl" language="en">Tables</localized-string><localized-string key="Requirement.sg" language="en">Requirement</localized-string><localized-string key="Requirement.pl" language="en">Requirements</localized-string><localized-string key="Recommendation.sg" language="en">Recommendation</localized-string><localized-string key="Recommendation.pl" language="en">Recommendations</localized-string><localized-string key="Permission.sg" language="en">Permission</localized-string><localized-string key="Permission.pl" language="en">Permissions</localized-string><localized-string key="Example.sg" language="en">Example</localized-string><localized-string key="Example.pl" language="en">Examples</localized-string><localized-string key="Part.sg" language="en">Part</localized-string><localized-string key="Part.pl" language="en">Parts</localized-string><localized-string key="Section.sg" language="en">Section</localized-string><localized-string key="Section.pl" language="en">Sections</localized-string><localized-string key="Paragraph.sg" language="en">Paragraph</localized-string><localized-string key="Paragraph.pl" language="en">Paragraphs</localized-string><localized-string key="Chapter.sg" language="en">Chapter</localized-string><localized-string key="Chapter.pl" language="en">Chapters</localized-string><localized-string key="Page.sg" language="en">Page</localized-string><localized-string key="Page.pl" language="en">Pages</localized-string><localized-string key="punct.colon" language="en">:</localized-string><localized-string key="punct.comma" language="en">,</localized-string><localized-string key="punct.enum-comma" language="en">,</localized-string><localized-string key="punct.semicolon" language="en">;</localized-string><localized-string key="punct.period" language="en">.</localized-string><localized-string key="punct.close-paren" language="en">)</localized-string><localized-string key="punct.open-paren" language="en">(</localized-string><localized-string key="punct.close-bracket" language="en">]</localized-string><localized-string key="punct.open-bracket" language="en">[</localized-string><localized-string key="punct.question-mark" language="en">?</localized-string><localized-string key="punct.exclamation-mark" language="en">!</localized-string><localized-string key="punct.em-dash" language="en">—</localized-string><localized-string key="punct.en-dash" language="en">–</localized-string><localized-string key="punct.number-en-dash" language="en">–</localized-string><localized-string key="punct.open-quote" language="en">“</localized-string><localized-string key="punct.close-quote" language="en">”</localized-string><localized-string key="punct.open-nested-quote" language="en">‘</localized-string><localized-string key="punct.close-nested-quote" language="en">’</localized-string><localized-string key="punct.ellipse" language="en">…</localized-string><localized-string key="language" language="en">en</localized-string><localized-string key="script" language="en">Latn</localized-string></localized-strings><metanorma-extension><semantic-metadata><stage-published>false</stage-published></semantic-metadata>
+<presentation-metadata><name>TOC Heading Levels</name><value>2</value></presentation-metadata><presentation-metadata><name>HTML TOC Heading Levels</name><value>2</value></presentation-metadata><presentation-metadata><name>DOC TOC Heading Levels</name><value>2</value></presentation-metadata><presentation-metadata><name>PDF TOC Heading Levels</name><value>2</value></presentation-metadata><source-highlighter-css>sourcecode table td { padding: 5px; }
+sourcecode table pre { margin: 0; }
+sourcecode, sourcecode .w {
+  color: #444444;
+}
+sourcecode .cp {
+  color: #CC00A3;
+}
+sourcecode .cs {
+  color: #CC00A3;
+}
+sourcecode .c, sourcecode .ch, sourcecode .cd, sourcecode .cm, sourcecode .cpf, sourcecode .c1 {
+  color: #FF0000;
+}
+sourcecode .kc {
+  color: #C34E00;
+}
+sourcecode .kd {
+  color: #0000FF;
+}
+sourcecode .kr {
+  color: #007575;
+}
+sourcecode .k, sourcecode .kn, sourcecode .kp, sourcecode .kt, sourcecode .kv {
+  color: #0000FF;
+}
+sourcecode .s, sourcecode .sb, sourcecode .sc, sourcecode .ld, sourcecode .sd, sourcecode .s2, sourcecode .se, sourcecode .sh, sourcecode .si, sourcecode .sx, sourcecode .sr, sourcecode .s1, sourcecode .ss {
+  color: #009C00;
+}
+sourcecode .sa {
+  color: #0000FF;
+}
+sourcecode .nb, sourcecode .bp {
+  color: #C34E00;
+}
+sourcecode .nt {
+  color: #0000FF;
+}
+
+</source-highlighter-css></metanorma-extension>
+<boilerplate><copyright-statement>
+
+<clause id="_9683bcac-482c-1a2a-b54e-0b9e6f9f4633" obligation="normative" semx-id="_9683bcac-482c-1a2a-b54e-0b9e6f9f4633"><p id="_b5dd4f69-230d-e0f1-22e6-8036e33a438e" semx-id="_b5dd4f69-230d-e0f1-22e6-8036e33a438e">© Ribose Asia Limited 2018</p>
+</clause>
+</copyright-statement>
+
+<license-statement>
+
+<clause id="_3179d22c-816d-e694-6037-341f744bc6dc" obligation="normative" semx-id="_3179d22c-816d-e694-6037-341f744bc6dc">
+<title id="_85c06a3a-92ab-6831-ecfc-51494a48f939" semx-id="_5ad8fb30-fcae-1072-87a2-407e6b4939ec">Warning for Drafts</title><fmt-title depth="1" id="_b086e732-8e6e-7df8-c2b4-ec745118b9e4"><semx element="title" source="_85c06a3a-92ab-6831-ecfc-51494a48f939">Warning for Drafts</semx></fmt-title>
+<p id="_a24807ee-0381-7ef8-1167-c3aacbb0fd73" semx-id="_a24807ee-0381-7ef8-1167-c3aacbb0fd73">This document is not a Ribose Standard. It is distributed for review and comment, and is subject to change without notice and may not be referred to as a Standard. Recipients of this draft are invited to submit, with their comments, notification of any relevant patent rights of which they are aware and to provide supporting documentation.</p>
+</clause>
+</license-statement>
+
+<legal-statement>
+
+<clause id="_7e0f3c63-3fc9-65cf-37f7-b94afa0dbc5d" obligation="normative" semx-id="_7e0f3c63-3fc9-65cf-37f7-b94afa0dbc5d"><p id="_50bbfa02-61c3-8332-bad8-61e7389d1808" semx-id="_50bbfa02-61c3-8332-bad8-61e7389d1808">All rights reserved. Unless otherwise specified, no part of this publication may be reproduced or utilized otherwise in any form or by any means, electronic or mechanical, including photocopying, or posting on the internet or an intranet, without prior written permission. Permission can be requested from the address below.</p>
+</clause>
+</legal-statement>
+
+<feedback-statement>
+
+<clause id="_d43a5e83-e752-e9bc-955e-4282a8ebb43a" obligation="normative" semx-id="_d43a5e83-e752-e9bc-955e-4282a8ebb43a"><p id="boilerplate-name" anchor="boilerplate-name" align="left" semx-id="_0145a561-c9cc-a509-4784-ac2a1e6ea922">Ribose Asia Limited</p>
+
+<p id="boilerplate-address" anchor="boilerplate-address" align="left" semx-id="_80954cc8-1f49-9d20-5987-829595995a92">Suite 1, 8/F, New Henry House<br/> 10 Ice House Street<br/> Central<br/> Hong Kong<br/> <br/> <link target="mailto:copyright@ribose.com" id="_266c0a97-1fa8-ceb2-57d4-c115e8b84704"/><semx element="link" source="_266c0a97-1fa8-ceb2-57d4-c115e8b84704"><fmt-link target="mailto:copyright@ribose.com"/></semx><br/> <link target="https://www.ribose.com" id="_0453541e-1ec3-a740-d6a4-6dfc5a822f3b">www.ribose.com</link><semx element="link" source="_0453541e-1ec3-a740-d6a4-6dfc5a822f3b"><fmt-link target="https://www.ribose.com">www.ribose.com</fmt-link></semx></p>
+</clause>
+</feedback-statement>
+</boilerplate><preface><clause type="toc" id="_13d7055e-30fc-845a-c60e-8972faf092d9" displayorder="1"><fmt-title depth="1" id="_b7371af6-75a1-52fa-2891-5c5f9a06aa7c">Contents</fmt-title></clause>
+<foreword id="_c7a19414-a61d-5672-3de1-321526f8a240" obligation="informative" semx-id="_c7a19414-a61d-5672-3de1-321526f8a240" displayorder="2">
+<title id="_39f555c2-f081-1181-eab4-26637491561a" semx-id="_41c9fad3-d4c1-eecc-4fad-f91704acc026">Foreword</title><fmt-title depth="1" id="_e21d5a0d-5d7c-f27a-d0d4-780199a274bb"><semx element="title" source="_39f555c2-f081-1181-eab4-26637491561a">Foreword</semx></fmt-title>
+<p id="_5b801359-66f7-8a14-2c8e-545f62e8761c" semx-id="_5b801359-66f7-8a14-2c8e-545f62e8761c">Ribose is the asymmetric security company.</p>
+
+<p id="_237b71c9-5451-d486-8dde-3f2e3942c0cc" semx-id="_237b71c9-5451-d486-8dde-3f2e3942c0cc">Ribose Group Inc. (“Ribose”) is global developer of <em>asymmetric security</em> technologies across user-centric systems and applications.</p>
+
+<p id="_0e0a4c0f-aa8e-36a7-1699-6ce1dffbde06" semx-id="_0e0a4c0f-aa8e-36a7-1699-6ce1dffbde06">Ribose works closely with international organizations such as ISO, CalConnect and the Cloud Security Alliance.</p>
+
+<p id="_91f78eb5-4fa2-c48b-6a0e-b9b5358c06c1" semx-id="_91f78eb5-4fa2-c48b-6a0e-b9b5358c06c1">The procedures used to develop this document and those intended for its further maintenance are described in the Ribose Standardization Directives.</p>
+
+<p id="_2aa4a2ab-762c-4ed3-94cd-3c71271e9ebe" semx-id="_2aa4a2ab-762c-4ed3-94cd-3c71271e9ebe">In particular the different approval criteria needed for the different types of Ribose documents should be noted. This document was drafted in accordance with the editorial rules of the Ribose Standardization Directives.</p>
+
+<p id="_16ee2ed5-907f-1462-97f2-6362345aa537" semx-id="_16ee2ed5-907f-1462-97f2-6362345aa537">Attention is drawn to the possibility that some of the elements of this document may be the subject of patent rights. Ribose shall not be held responsible for identifying any or all such patent rights. Details of any patent rights identified during the development of the document will be in the Introduction.</p>
+
+<p id="_7a4eac49-548a-2c85-8064-27286bfee4cc" semx-id="_7a4eac49-548a-2c85-8064-27286bfee4cc">Any trade name used in this document is information given for the convenience of users and does not constitute an endorsement.</p>
+
+<p id="_d4111259-0588-fe92-f3b6-c342de8e9e15" semx-id="_d4111259-0588-fe92-f3b6-c342de8e9e15">This document was prepared by the Ribose Committee <em>{technical-committee}</em>.</p>
+</foreword><introduction id="introduction" anchor="introduction" obligation="informative" semx-id="_fb41ebd3-ff07-f0c7-467a-b87834cae151" displayorder="3">
+<title id="_16dfa240-5da0-7fab-88e4-5f6086712be3" semx-id="_2b2e98d1-114a-3da4-8556-01ae0a724280">Introduction</title><fmt-title depth="1" id="_a9308b12-1a9d-9521-6b7d-acebab74aa90"><semx element="title" source="_16dfa240-5da0-7fab-88e4-5f6086712be3">Introduction</semx></fmt-title>
+<p id="_fedfa692-4771-9b3f-40ad-e8008e801af2" semx-id="_fedfa692-4771-9b3f-40ad-e8008e801af2">The Nereon project aims to unify and glue together cloud configuration management through the Nereon data models.</p>
+
+<p id="_ffdc9f30-a106-5537-f5d5-f4a6a5698a6f" semx-id="_ffdc9f30-a106-5537-f5d5-f4a6a5698a6f">The Nereon Object Configuration syntax (NOC) and Nereon Object Configuration Schema syntax (NOS) are methods used to express configuration settings in Nereon data models, and can also be used as interchangeable files.</p>
+
+<p id="_52606c5c-e71a-b74e-654e-a913b8d99df1" semx-id="_52606c5c-e71a-b74e-654e-a913b8d99df1">Nereon models: <link target="https://github.com/riboseinc/nereon-models" id="_8c781b83-e861-4ee7-f2bc-8dc2d304afc6"/><semx element="link" source="_8c781b83-e861-4ee7-f2bc-8dc2d304afc6"><fmt-link target="https://github.com/riboseinc/nereon-models"/></semx></p>
+
+<p id="_cf3fec68-a925-1a67-07dc-8c1fbb1de364" semx-id="_cf3fec68-a925-1a67-07dc-8c1fbb1de364">Nereon is a play on Nereus, the shapeshifting sea god of the Greeks, the eldest son of Pontus and Gaia. “Nereon” literally means “place of Nereus”, representing the shape-shifting nature of configuration.</p>
+</introduction></preface><sections>
+
+<clause id="scope" anchor="scope" type="scope" obligation="normative" semx-id="_9b89cf53-d63c-7866-cdf2-50c89bb9063f" displayorder="4">
+<title id="_27f24c52-47bf-ede9-a9bc-0030108e9c77" semx-id="_f70b6ff6-6131-0e24-81e1-850dbe94b63d">Scope</title><fmt-title depth="1" id="_a49d63b7-87c4-3bc5-ea2b-e2121f2524d3"><span class="fmt-caption-label"><semx element="autonum" source="scope">1</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_27f24c52-47bf-ede9-a9bc-0030108e9c77">Scope</semx></fmt-title><fmt-xref-label><span class="fmt-element-name">Clause</span> <semx element="autonum" source="scope">1</semx></fmt-xref-label>
+<p id="_0cc731f7-f4ef-6b44-fd42-738a9f069e1e" semx-id="_0cc731f7-f4ef-6b44-fd42-738a9f069e1e">This document defines the Nereon Object Configuration Syntax (NOC) and Nereon Object Configuration Schema Syntax (NOS).</p>
+
+<p id="_2ff6e7d2-70e9-4c02-8b57-30fa5d02cc29" semx-id="_2ff6e7d2-70e9-4c02-8b57-30fa5d02cc29">(TODO.)</p>
+</clause>
+
+
+
+<clause id="terms" anchor="terms" obligation="normative" type="terms" semx-id="_ac84dec4-f0ca-8468-e717-32240f574ed6" displayorder="6">
+<title id="_cf736288-ace8-5bfc-cd0d-ea6add015555" semx-id="_f0298eaf-2928-f7db-4bd7-7c7ee0901425">Terms, definitions and symbols</title><fmt-title depth="1" id="_887ef84f-ddbb-a857-df65-30eebedaad40"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_cf736288-ace8-5bfc-cd0d-ea6add015555">Terms, definitions and symbols</semx></fmt-title><fmt-xref-label><span class="fmt-element-name">Clause</span> <semx element="autonum" source="terms">3</semx></fmt-xref-label><p id="_0f2bd13d-b1b2-1669-067b-a429dd7c2ced" semx-id="_0f2bd13d-b1b2-1669-067b-a429dd7c2ced">For the purposes of this document, the following terms and definitions apply.</p>
+
+<terms id="_f5897bb4-a721-4ea3-4927-980a21fe06c2" obligation="normative" semx-id="_f5897bb4-a721-4ea3-4927-980a21fe06c2">
+<title id="_2a6fbf9b-a434-599c-1faf-6a03275efbce" semx-id="_e0d415dd-ab5d-77a3-3b7b-4734a8205eb4">Terms and definitions</title><fmt-title depth="2" id="_dd4d3fdc-4cfa-4c88-adf7-f463acccefd6"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_2a6fbf9b-a434-599c-1faf-6a03275efbce">Terms and definitions</semx></fmt-title><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx></fmt-xref-label>
+<term id="term-user" anchor="term-user" semx-id="_2fad3090-e485-14d9-0882-fedc9a7afaa7"><fmt-name id="_669fba1e-a1ce-000e-3ae0-2c0aef6dd7fc"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-user">1</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-user">1</semx></fmt-xref-label><preferred id="_38db3073-ce6e-407e-e03c-831d70fd5d59"><expression>
+<name>user</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_38db3073-ce6e-407e-e03c-831d70fd5d59">user</semx></p></fmt-preferred>
+<definition id="_5b72b4b6-263e-2f61-fd38-be6eb9103ce0" semx-id="_5b72b4b6-263e-2f61-fd38-be6eb9103ce0"><verbal-definition semx-id="_0c2abb7c-25fc-0006-311d-dfd7547ab913" id="_0c2abb7c-25fc-0006-311d-dfd7547ab913"><p semx-id="_77b3ebfa-2e84-392e-258d-80af36904da9" original-id="_77b3ebfa-2e84-392e-258d-80af36904da9">person that utilizes a service</p></verbal-definition></definition><fmt-definition id="_3d822c84-b1c6-17fe-ce5f-67151eb7d13e"><semx element="definition" source="_5b72b4b6-263e-2f61-fd38-be6eb9103ce0"><p id="_77b3ebfa-2e84-392e-258d-80af36904da9" semx-id="_77b3ebfa-2e84-392e-258d-80af36904da9">person that utilizes a service</p></semx></fmt-definition>
+ </term>
+
+<term id="term-access-control" anchor="term-access-control" semx-id="_b22ac75d-4e5c-f4da-ac43-84bafdf00d2e"><fmt-name id="_4a636698-1801-e80f-dfd5-9a8ba4953f3e"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-access-control">2</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-access-control">2</semx></fmt-xref-label><preferred id="_f14115a3-4894-2711-da7d-9254bd615a90"><expression>
+<name>access control</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_f14115a3-4894-2711-da7d-9254bd615a90">access control</semx></p></fmt-preferred>
+<definition id="_44f98362-8719-3295-9aa0-d77875e1f079" semx-id="_44f98362-8719-3295-9aa0-d77875e1f079"><verbal-definition semx-id="_ecb374fc-8be8-1a40-dcb2-3acdd23cf1fb" id="_ecb374fc-8be8-1a40-dcb2-3acdd23cf1fb"><p semx-id="_5ec04046-9c47-3fb6-0ed7-d48de68de2ac" original-id="_5ec04046-9c47-3fb6-0ed7-d48de68de2ac">TODO.</p></verbal-definition></definition><fmt-definition id="_1cb076a5-cf29-0a5e-630c-20fe2b0eb9dd"><semx element="definition" source="_44f98362-8719-3295-9aa0-d77875e1f079"><p id="_5ec04046-9c47-3fb6-0ed7-d48de68de2ac" semx-id="_5ec04046-9c47-3fb6-0ed7-d48de68de2ac">TODO.</p></semx></fmt-definition>
+ </term>
+
+<term id="term-author" anchor="term-author" semx-id="_be662f6d-2af6-c835-b988-e58185c8c8a5"><fmt-name id="_a302aca5-5ba2-3b6d-9b9e-72a04c4b27f3"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-author">3</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-author">3</semx></fmt-xref-label><preferred id="_ec620d3b-193e-2ad1-7f5e-424953ca5c0e"><expression>
+<name>author</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_ec620d3b-193e-2ad1-7f5e-424953ca5c0e">author</semx></p></fmt-preferred>
+<definition id="_2c68468e-2e13-6888-212f-d47c48ad8546" semx-id="_2c68468e-2e13-6888-212f-d47c48ad8546"><verbal-definition semx-id="_834daa6c-4446-77c7-3bba-2fef32f93160" id="_834daa6c-4446-77c7-3bba-2fef32f93160"><p semx-id="_bc8034d5-2c85-8a7d-3fb9-c7d175e6dd5d" original-id="_bc8034d5-2c85-8a7d-3fb9-c7d175e6dd5d">TODO.</p></verbal-definition></definition><fmt-definition id="_3bd0d1a8-e31d-44fe-8856-be928108e654"><semx element="definition" source="_2c68468e-2e13-6888-212f-d47c48ad8546"><p id="_bc8034d5-2c85-8a7d-3fb9-c7d175e6dd5d" semx-id="_bc8034d5-2c85-8a7d-3fb9-c7d175e6dd5d">TODO.</p></semx></fmt-definition>
+ </term>
+
+<term id="term-role" anchor="term-role" semx-id="_ccf542b9-f751-e5fc-f059-014c684ac82b"><fmt-name id="_bdfa4e24-9e6f-d196-1c3e-943ce52ae369"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-role">4</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-role">4</semx></fmt-xref-label><preferred id="_e2a07133-dfb3-4455-6f36-a2b9e6f439c1"><expression>
+<name>role</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_e2a07133-dfb3-4455-6f36-a2b9e6f439c1">role</semx></p></fmt-preferred>
+<definition id="_a65680be-6177-d4e6-e77c-0bc4619b8d77" semx-id="_a65680be-6177-d4e6-e77c-0bc4619b8d77"><verbal-definition semx-id="_9d8d116f-1190-9123-8b40-c303e0feb9c6" id="_9d8d116f-1190-9123-8b40-c303e0feb9c6"><p semx-id="_75c81165-1cf1-dc0e-980b-4e81876511a7" original-id="_75c81165-1cf1-dc0e-980b-4e81876511a7">TODO.</p></verbal-definition></definition><fmt-definition id="_6084e121-00c2-2501-f88a-627b9d44421a"><semx element="definition" source="_a65680be-6177-d4e6-e77c-0bc4619b8d77"><p id="_75c81165-1cf1-dc0e-980b-4e81876511a7" semx-id="_75c81165-1cf1-dc0e-980b-4e81876511a7">TODO.</p></semx></fmt-definition>
+ </term>
+
+<term id="term-classification" anchor="term-classification" semx-id="_0528940f-e881-e16f-e0cb-1195c14062f7"><fmt-name id="_201f0581-1eec-0076-f36a-806884384696"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-classification">5</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-classification">5</semx></fmt-xref-label><preferred id="_e0880e71-2382-0c70-9bec-c4994c8c99f5"><expression>
+<name>classification</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_e0880e71-2382-0c70-9bec-c4994c8c99f5">classification</semx></p></fmt-preferred>
+<definition id="_84ac5719-27f4-52ba-b985-f52faa0c7695" semx-id="_84ac5719-27f4-52ba-b985-f52faa0c7695"><verbal-definition semx-id="_ca7d23f0-4132-c31f-a291-2cdf1235a954" id="_ca7d23f0-4132-c31f-a291-2cdf1235a954"><p semx-id="_e85553e0-6bcf-062c-81a9-a1dd6548bec8" original-id="_e85553e0-6bcf-062c-81a9-a1dd6548bec8">TODO.</p></verbal-definition></definition><fmt-definition id="_89955d1c-cf3d-8d22-6a36-79f3817aabbb"><semx element="definition" source="_84ac5719-27f4-52ba-b985-f52faa0c7695"><p id="_e85553e0-6bcf-062c-81a9-a1dd6548bec8" semx-id="_e85553e0-6bcf-062c-81a9-a1dd6548bec8">TODO.</p></semx></fmt-definition>
+ </term>
+
+<term id="term-classification-label" anchor="term-classification-label" semx-id="_50a3476c-9f56-4548-cdd9-31196172e8d3"><fmt-name id="_d1e1c031-97c5-93a4-d2d8-f553e1908390"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-classification-label">6</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-classification-label">6</semx></fmt-xref-label><preferred id="_de0ce5e4-d6d3-c13c-4953-5cf7e671d9aa"><expression>
+<name>classification label</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_de0ce5e4-d6d3-c13c-4953-5cf7e671d9aa">classification label</semx></p></fmt-preferred>
+<definition id="_b75b5887-f496-23ab-3f86-d0e52aa707cf" semx-id="_b75b5887-f496-23ab-3f86-d0e52aa707cf"><verbal-definition semx-id="_4589bcde-4684-6f0b-ef22-b2c294d44de0" id="_4589bcde-4684-6f0b-ef22-b2c294d44de0"><p semx-id="_4571273d-3de3-c6eb-b621-664e4db8cd79" original-id="_4571273d-3de3-c6eb-b621-664e4db8cd79">TODO.</p></verbal-definition></definition><fmt-definition id="_a0a20853-4235-aa05-e404-8fea4ad82be1"><semx element="definition" source="_b75b5887-f496-23ab-3f86-d0e52aa707cf"><p id="_4571273d-3de3-c6eb-b621-664e4db8cd79" semx-id="_4571273d-3de3-c6eb-b621-664e4db8cd79">TODO.</p></semx></fmt-definition>
+ </term>
+
+<term id="term-content-addressable-storage" anchor="term-content-addressable-storage" semx-id="_a78f770c-85a4-d578-0378-a8ccd51ed274"><fmt-name id="_5e79b1ca-52dc-f3a9-f126-f6a085b73a7b"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-content-addressable-storage">7</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-content-addressable-storage">7</semx></fmt-xref-label><preferred id="_e113c199-ddca-99b0-19d8-48e922b8d6a7"><expression>
+<name>content addressable storage</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_e113c199-ddca-99b0-19d8-48e922b8d6a7">content addressable storage</semx></p></fmt-preferred>
+<definition id="_c2abe44e-9d45-e2b6-a163-52c74ff24314" semx-id="_c2abe44e-9d45-e2b6-a163-52c74ff24314"><verbal-definition semx-id="_41b5c698-ed2c-b872-0e9d-1ede7324e7c6" id="_41b5c698-ed2c-b872-0e9d-1ede7324e7c6"><p semx-id="_a53738ae-0242-dd8e-fbb7-72f869630587" original-id="_a53738ae-0242-dd8e-fbb7-72f869630587">TODO.</p></verbal-definition></definition><fmt-definition id="_5ea331a1-b4a4-a9ef-d47e-18ce7de7c46d"><semx element="definition" source="_c2abe44e-9d45-e2b6-a163-52c74ff24314"><p id="_a53738ae-0242-dd8e-fbb7-72f869630587" semx-id="_a53738ae-0242-dd8e-fbb7-72f869630587">TODO.</p></semx></fmt-definition>
+ </term>
+
+<term id="term-forward-secrecy" anchor="term-forward-secrecy" semx-id="_4fcc5f52-2f43-f9a5-d8d0-f3976f8772db"><fmt-name id="_95177bb0-ba5f-896d-3699-1ecb18f2ebb9"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-forward-secrecy">8</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-forward-secrecy">8</semx></fmt-xref-label><preferred id="_2116d172-f47d-814c-e8da-be35df7f7f19"><expression>
+<name>forward secrecy</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_2116d172-f47d-814c-e8da-be35df7f7f19">forward secrecy</semx></p></fmt-preferred>
+<definition id="_819b9751-8d8c-80dd-e720-a38e94cdc99d" semx-id="_819b9751-8d8c-80dd-e720-a38e94cdc99d"><verbal-definition semx-id="_7fe02cb5-721d-afd7-8b74-2abf70056da7" id="_7fe02cb5-721d-afd7-8b74-2abf70056da7"><p semx-id="_d9d015b5-af68-1e21-5836-f384fcc51db4" original-id="_d9d015b5-af68-1e21-5836-f384fcc51db4">method such that user of revoked access is unable to access data created after access revocation</p></verbal-definition></definition><fmt-definition id="_d47d16d9-c3e6-37f4-aa8b-a80ad91a4842"><semx element="definition" source="_819b9751-8d8c-80dd-e720-a38e94cdc99d"><p id="_d9d015b5-af68-1e21-5836-f384fcc51db4" semx-id="_d9d015b5-af68-1e21-5836-f384fcc51db4">method such that user of revoked access is unable to access data created after access revocation</p></semx></fmt-definition>
+
+
+ <termnote id="_224dfb71-9d8d-f89b-5c60-150818a2d613" semx-id="_224dfb71-9d8d-f89b-5c60-150818a2d613" autonum="1"><fmt-name id="_7d81a33a-debf-353d-e6a5-05f072d68ae2"><span class="fmt-caption-label">Note <semx element="autonum" source="_224dfb71-9d8d-f89b-5c60-150818a2d613">1</semx> to entry</span><span class="fmt-label-delim">: </span></fmt-name><fmt-xref-label><span class="fmt-element-name">Note</span> <semx element="autonum" source="_224dfb71-9d8d-f89b-5c60-150818a2d613">1</semx></fmt-xref-label><fmt-xref-label container="term-forward-secrecy"><span class="fmt-xref-container"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-forward-secrecy">8</semx></span><span class="fmt-comma">,</span> <span class="fmt-element-name">Note</span> <semx element="autonum" source="_224dfb71-9d8d-f89b-5c60-150818a2d613">1</semx></fmt-xref-label><p id="_1a25329c-e742-5272-7b0a-6d58db6a3e8b" semx-id="_1a25329c-e742-5272-7b0a-6d58db6a3e8b">Refer to <xref target="RFC7525" id="_db0ec09c-f846-7522-0378-be2ae299cb0c">section 6.3</xref><semx element="xref" source="_db0ec09c-f846-7522-0378-be2ae299cb0c"><fmt-xref target="RFC7525">section 6.3</fmt-xref></semx></p>
+</termnote></term>
+
+<term id="term-public-key-infrastructure" anchor="term-public-key-infrastructure" semx-id="_f964b718-3b23-d99a-7c6b-5c132b45dc3a"><fmt-name id="_a847a74b-c56c-4bd4-f0c4-a6198f93142b"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-public-key-infrastructure">9</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-public-key-infrastructure">9</semx></fmt-xref-label><preferred id="_bab39315-d5a3-07a6-dbd5-f8a09d1dfe63"><expression>
+<name>public key infrastructure</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_bab39315-d5a3-07a6-dbd5-f8a09d1dfe63">public key infrastructure</semx></p></fmt-preferred><admitted id="_7f0e6c39-012c-dc69-a36a-4f3b655670fa"><expression>
+<name>PKI</name>
+</expression>
+</admitted><fmt-admitted><p><semx element="admitted" source="_7f0e6c39-012c-dc69-a36a-4f3b655670fa">PKI</semx></p></fmt-admitted>
+
+
+
+<definition id="_fcdf60a3-f51b-3ec3-d82e-9e45a82d2155" semx-id="_fcdf60a3-f51b-3ec3-d82e-9e45a82d2155"><verbal-definition semx-id="_de2473ba-eeab-be58-6698-f1e8862972c4" id="_de2473ba-eeab-be58-6698-f1e8862972c4"><p semx-id="_dbcddaaf-4bda-3dd7-3a40-38aca6a85874" original-id="_dbcddaaf-4bda-3dd7-3a40-38aca6a85874">TODO.</p></verbal-definition></definition><fmt-definition id="_fe2db7c0-9a0c-2af4-c0d4-dcb638f99217"><semx element="definition" source="_fcdf60a3-f51b-3ec3-d82e-9e45a82d2155"><p id="_dbcddaaf-4bda-3dd7-3a40-38aca6a85874" semx-id="_dbcddaaf-4bda-3dd7-3a40-38aca6a85874">TODO.</p></semx></fmt-definition>
+ </term>
+
+<term id="term-blockcipher" anchor="term-blockcipher" semx-id="_edd106e4-3034-3d53-6ba3-a5f3a2f9b9ff"><fmt-name id="_447360d3-d152-7430-8fb6-260ef8b65282"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-blockcipher">10</semx><span class="fmt-autonum-delim">.</span></span></fmt-name><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_f5897bb4-a721-4ea3-4927-980a21fe06c2">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="term-blockcipher">10</semx></fmt-xref-label><preferred id="_d54c4760-57a7-3c60-cf67-7ce6a08d331b"><expression>
+<name>blockcipher</name>
+</expression>
+</preferred><fmt-preferred><p><semx element="preferred" source="_d54c4760-57a7-3c60-cf67-7ce6a08d331b">blockcipher</semx></p></fmt-preferred>
+<definition id="_2f22405a-1437-f1eb-3952-8b7521579857" semx-id="_2f22405a-1437-f1eb-3952-8b7521579857"><verbal-definition semx-id="_103cd392-bc16-664b-e3d0-1b2efdcf1aaf" id="_103cd392-bc16-664b-e3d0-1b2efdcf1aaf"><p semx-id="_60badabd-88bc-874a-5ac0-27269084474f" original-id="_60badabd-88bc-874a-5ac0-27269084474f">encryption algorithm that encrypts a plaintext into an equivalent sized ciphertext, using an identical key for encryption and decryption</p></verbal-definition></definition><fmt-definition id="_f4825d6b-5c15-dff0-3491-28d5d9fb8107"><semx element="definition" source="_2f22405a-1437-f1eb-3952-8b7521579857"><p id="_60badabd-88bc-874a-5ac0-27269084474f" semx-id="_60badabd-88bc-874a-5ac0-27269084474f">encryption algorithm that encrypts a plaintext into an equivalent sized ciphertext, using an identical key for encryption and decryption</p></semx></fmt-definition>
+ </term>
+</terms>
+
+<definitions id="_531b06f8-2840-ff3b-399b-65cf17b78099" type="symbols" obligation="normative" semx-id="_531b06f8-2840-ff3b-399b-65cf17b78099">
+<title id="_b4f2913e-6744-952d-d3cc-b2d2d8283be1" semx-id="_df71ff91-34fb-ca20-4838-d7bd6db1f694">Symbols</title><fmt-title depth="2" id="_3f66ae4c-75f1-9cda-6e5c-4237f2e66b03"><span class="fmt-caption-label"><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_531b06f8-2840-ff3b-399b-65cf17b78099">2</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_b4f2913e-6744-952d-d3cc-b2d2d8283be1">Symbols</semx></fmt-title><fmt-xref-label><semx element="autonum" source="terms">3</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_531b06f8-2840-ff3b-399b-65cf17b78099">2</semx></fmt-xref-label>
+<dl id="_c6ed600e-7d31-b9aa-5cbe-4702d8cab47b" semx-id="_c6ed600e-7d31-b9aa-5cbe-4702d8cab47b"><dt anchor="symbol-BCD_K_-m_" id="symbol-BCD_K_-m_" semx-id="_f9ee58d2-77b0-35d6-7d66-378afe96ea7c">
+  <stem block="false" type="MathML" id="_aecbe100-a8e3-f959-d3f9-75fcd4ee8c50">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>B</mi>
+    <mi>C</mi>
+    <mi>D</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>K</mi>
+      <mo>,</mo>
+      <mi>m</mi>
+      <mo>)</mo>
+    </mrow>
+  </mstyle>
+</math>
+    <asciimath>BCD(K, m)</asciimath>
+  </stem><fmt-stem type="MathML"><semx element="stem" source="_aecbe100-a8e3-f959-d3f9-75fcd4ee8c50">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>B</mi>
+    <mi>C</mi>
+    <mi>D</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>K</mi>
+      <mo>,</mo>
+      <mi>m</mi>
+      <mo>)</mo>
+    </mrow>
+  </mstyle>
+</math>
+    <asciimath>BCD(K, m)</asciimath>
+  </semx></fmt-stem></dt><dd id="_ab39add3-896e-cd3b-140d-15b3d0a68c2c" semx-id="_ab39add3-896e-cd3b-140d-15b3d0a68c2c"><p id="_2780cf8a-e679-2a33-422d-56dd43db1288" semx-id="_2780cf8a-e679-2a33-422d-56dd43db1288">Symmetric decryption, through the blockcipher <stem block="false" type="MathML" id="_20c2bba8-02f7-ea9d-4a8f-dbad8618bfd8"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>B</mi>
+    <mi>C</mi>
+  </mstyle>
+</math><asciimath>BC</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_20c2bba8-02f7-ea9d-4a8f-dbad8618bfd8"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>B</mi>
+    <mi>C</mi>
+  </mstyle>
+</math><asciimath>BC</asciimath></semx></fmt-stem>, of the message
+<stem block="false" type="MathML" id="_91741561-c13a-8d46-a965-7e082c64f747"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>m</mi>
+  </mstyle>
+</math><asciimath>m</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_91741561-c13a-8d46-a965-7e082c64f747"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>m</mi>
+  </mstyle>
+</math><asciimath>m</asciimath></semx></fmt-stem> using the key <stem block="false" type="MathML" id="_4f7b05b4-d3de-7fb3-b01e-c893f252b2c8"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>K</mi>
+  </mstyle>
+</math><asciimath>K</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_4f7b05b4-d3de-7fb3-b01e-c893f252b2c8"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>K</mi>
+  </mstyle>
+</math><asciimath>K</asciimath></semx></fmt-stem></p>
+</dd>
+<dt anchor="symbol-BCE_K_-m_" id="symbol-BCE_K_-m_" semx-id="_e24614f4-885a-438a-4f86-18b375a8eb30">
+  <stem block="false" type="MathML" id="_d24c86f2-824a-2788-479c-c42a459cdf23">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>B</mi>
+    <mi>C</mi>
+    <mi>E</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>K</mi>
+      <mo>,</mo>
+      <mi>m</mi>
+      <mo>)</mo>
+    </mrow>
+  </mstyle>
+</math>
+    <asciimath>BCE(K, m)</asciimath>
+  </stem><fmt-stem type="MathML"><semx element="stem" source="_d24c86f2-824a-2788-479c-c42a459cdf23">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>B</mi>
+    <mi>C</mi>
+    <mi>E</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>K</mi>
+      <mo>,</mo>
+      <mi>m</mi>
+      <mo>)</mo>
+    </mrow>
+  </mstyle>
+</math>
+    <asciimath>BCE(K, m)</asciimath>
+  </semx></fmt-stem></dt><dd id="_f95fc928-e3d6-e480-1a2d-c9fda9508041" semx-id="_f95fc928-e3d6-e480-1a2d-c9fda9508041"><p id="_3d8e1c3b-f6cc-2c60-f947-6da19256eb0c" semx-id="_3d8e1c3b-f6cc-2c60-f947-6da19256eb0c">Symmetric encryption, through the blockcipher <stem block="false" type="MathML" id="_0a558dc1-a4a6-27ef-75f0-34e872fe3fe3"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>B</mi>
+    <mi>C</mi>
+  </mstyle>
+</math><asciimath>BC</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_0a558dc1-a4a6-27ef-75f0-34e872fe3fe3"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>B</mi>
+    <mi>C</mi>
+  </mstyle>
+</math><asciimath>BC</asciimath></semx></fmt-stem>, of the message
+<stem block="false" type="MathML" id="_eb4444a2-a64b-da92-3c34-be88c88e39b6"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>m</mi>
+  </mstyle>
+</math><asciimath>m</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_eb4444a2-a64b-da92-3c34-be88c88e39b6"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>m</mi>
+  </mstyle>
+</math><asciimath>m</asciimath></semx></fmt-stem> using the key <stem block="false" type="MathML" id="_fe21b2dd-71f7-4247-e155-782765d58726"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>K</mi>
+  </mstyle>
+</math><asciimath>K</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_fe21b2dd-71f7-4247-e155-782765d58726"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>K</mi>
+  </mstyle>
+</math><asciimath>K</asciimath></semx></fmt-stem></p>
+</dd>
+<dt anchor="symbol-D_K_-m_" id="symbol-D_K_-m_" semx-id="_1f88a6aa-05ea-1ee9-7ead-9ddfda914f00">
+  <stem block="false" type="MathML" id="_109f53d5-7471-11f7-9840-60c10832b49e">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>D</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>K</mi>
+      <mo>,</mo>
+      <mi>m</mi>
+      <mo>)</mo>
+    </mrow>
+  </mstyle>
+</math>
+    <asciimath>D(K, m)</asciimath>
+  </stem><fmt-stem type="MathML"><semx element="stem" source="_109f53d5-7471-11f7-9840-60c10832b49e">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>D</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>K</mi>
+      <mo>,</mo>
+      <mi>m</mi>
+      <mo>)</mo>
+    </mrow>
+  </mstyle>
+</math>
+    <asciimath>D(K, m)</asciimath>
+  </semx></fmt-stem></dt><dd id="_9fb1984c-4b3d-5010-d7d1-851b63198984" semx-id="_9fb1984c-4b3d-5010-d7d1-851b63198984"><p id="_992b26c9-0043-0da5-82bb-d04c1d567225" semx-id="_992b26c9-0043-0da5-82bb-d04c1d567225">Decryption of the message <stem block="false" type="MathML" id="_c149de51-0175-d56f-6770-2674dac7883a"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>m</mi>
+  </mstyle>
+</math><asciimath>m</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_c149de51-0175-d56f-6770-2674dac7883a"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>m</mi>
+  </mstyle>
+</math><asciimath>m</asciimath></semx></fmt-stem> using a key of an asymmetric keypair <stem block="false" type="MathML" id="_7479357b-3a94-68cc-0bf7-7faad4bd0378"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>K</mi>
+  </mstyle>
+</math><asciimath>K</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_7479357b-3a94-68cc-0bf7-7faad4bd0378"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>K</mi>
+  </mstyle>
+</math><asciimath>K</asciimath></semx></fmt-stem></p>
+</dd>
+<dt anchor="symbol-E_K_-m_" id="symbol-E_K_-m_" semx-id="_84bc5bf7-45b3-ffd4-19da-730b06f0f3bc">
+  <stem block="false" type="MathML" id="_a5e9fff1-d86d-ad58-3a84-382d37ab9d22">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>E</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>K</mi>
+      <mo>,</mo>
+      <mi>m</mi>
+      <mo>)</mo>
+    </mrow>
+  </mstyle>
+</math>
+    <asciimath>E(K, m)</asciimath>
+  </stem><fmt-stem type="MathML"><semx element="stem" source="_a5e9fff1-d86d-ad58-3a84-382d37ab9d22">
+    <math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>E</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>K</mi>
+      <mo>,</mo>
+      <mi>m</mi>
+      <mo>)</mo>
+    </mrow>
+  </mstyle>
+</math>
+    <asciimath>E(K, m)</asciimath>
+  </semx></fmt-stem></dt><dd id="_71b3dbef-f359-0627-ec53-b861c8aa022c" semx-id="_71b3dbef-f359-0627-ec53-b861c8aa022c"><p id="_31791d22-de1b-52cc-04de-cbc77b942dea" semx-id="_31791d22-de1b-52cc-04de-cbc77b942dea">Encryption of the message <stem block="false" type="MathML" id="_a939ec05-833e-1685-8de4-aadd80c2ce39"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>m</mi>
+  </mstyle>
+</math><asciimath>m</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_a939ec05-833e-1685-8de4-aadd80c2ce39"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>m</mi>
+  </mstyle>
+</math><asciimath>m</asciimath></semx></fmt-stem> using a key of an asymmetric keypair <stem block="false" type="MathML" id="_56946087-9c16-733e-6d6f-4b89f2d91efd"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>K</mi>
+  </mstyle>
+</math><asciimath>K</asciimath></stem><fmt-stem type="MathML"><semx element="stem" source="_56946087-9c16-733e-6d6f-4b89f2d91efd"><math xmlns="http://www.w3.org/1998/Math/MathML">
+  <mstyle displaystyle="false">
+    <mi>K</mi>
+  </mstyle>
+</math><asciimath>K</asciimath></semx></fmt-stem></p>
+</dd></dl>
+</definitions></clause>
+
+<clause id="syntax" anchor="syntax" obligation="normative" semx-id="_886a7fad-55d5-3dfd-b43b-173c80465f8a" displayorder="7">
+<title id="_430e597b-23f6-efd5-e963-f046359e3944" semx-id="_d0da60bb-ae63-2fb6-35b9-83b81373d1e6">Nereon Configuration and Schema Syntax</title><fmt-title depth="1" id="_1356dc44-725d-21d0-a550-31929261060a"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_430e597b-23f6-efd5-e963-f046359e3944">Nereon Configuration and Schema Syntax</semx></fmt-title><fmt-xref-label><span class="fmt-element-name">Clause</span> <semx element="autonum" source="syntax">4</semx></fmt-xref-label>
+<p id="_387bf3ec-59b9-eac9-8d2e-f929508592a0" semx-id="_387bf3ec-59b9-eac9-8d2e-f929508592a0">Nereon configurations (NOC) and schemas (NOS) are described using Nereon object notation (NON). NON is a structured configuration language influenced by JSON, UCL and HCL using a syntax influenced by traditional shell interfaces.</p>
+
+<p id="_79714c72-b2bb-8ae8-f827-216af7a65fd3" semx-id="_79714c72-b2bb-8ae8-f827-216af7a65fd3">NON templates can be defined to capture and reuse values and NON interpolation functions provide a mechanism for manipulating values when configuration is parsed.</p>
+
+<clause id="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0" obligation="normative" semx-id="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">
+<title id="_8b32604c-d738-f049-dc71-71dd30548b0c" semx-id="_53c49f16-4923-cce4-2a8b-4cc2693c9ac3">Document Structure</title><fmt-title depth="2" id="_7202602f-10e0-5517-801a-c6f0ec835a6b"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_8b32604c-d738-f049-dc71-71dd30548b0c">Document Structure</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx></fmt-xref-label>
+<p id="_88f3f841-01b5-40a4-e650-5ad0ebb5e229" semx-id="_88f3f841-01b5-40a4-e650-5ad0ebb5e229">NON defines three types of value; table, list and string. A table is a list of named values where names are strings. A list is an ordered list of values. A string is a textual representation of data.</p>
+
+<p id="_458e91b0-0632-cf96-cbe3-7ad5aefcf6da" semx-id="_458e91b0-0632-cf96-cbe3-7ad5aefcf6da">NON data MUST be utf8 encoded.</p>
+
+<p id="_eb0441a8-f994-34f1-06ba-adb129095e67" semx-id="_eb0441a8-f994-34f1-06ba-adb129095e67">A NON document comprises a single NON table value.</p>
+
+<clause id="_a0e2da22-be33-405c-330f-fb0e10ca7761" obligation="normative" semx-id="_a0e2da22-be33-405c-330f-fb0e10ca7761">
+<title id="_0c12d58e-6621-e83c-18e0-e453db73bd62" semx-id="_07e2a1fb-fc35-4ee7-9898-40284e277da2">Special Characters</title><fmt-title depth="3" id="_7a8662d5-fac6-d834-3f54-e34a76410dad"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_a0e2da22-be33-405c-330f-fb0e10ca7761">1</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_0c12d58e-6621-e83c-18e0-e453db73bd62">Special Characters</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_a0e2da22-be33-405c-330f-fb0e10ca7761">1</semx></fmt-xref-label>
+<p id="_c68c3de4-7078-6b65-f75e-c72908c84c2f" semx-id="_c68c3de4-7078-6b65-f75e-c72908c84c2f">There are a number of characters that have special meaning within a NON document. All other characters are considered part of a string value. The special characters are:</p>
+
+<table id="_52df7352-061f-c7ce-d5e1-8ac31069a476" unnumbered="true" semx-id="_52df7352-061f-c7ce-d5e1-8ac31069a476"><thead><tr id="_f6219d9a-57bf-d984-8f11-58a9ba794b84" semx-id="_f6219d9a-57bf-d984-8f11-58a9ba794b84"><th id="_2dfbc48d-4aaf-8821-b9d9-fa0e375c4c35" valign="top" align="left" semx-id="_2dfbc48d-4aaf-8821-b9d9-fa0e375c4c35">Character</th>
+<th id="_fcc5d170-6207-2c7a-ba66-f4636f7834fc" valign="top" align="left" semx-id="_fcc5d170-6207-2c7a-ba66-f4636f7834fc">ASCII</th>
+<th id="_28908d1a-82d1-76aa-1d20-5663a03e5208" valign="top" align="left" semx-id="_28908d1a-82d1-76aa-1d20-5663a03e5208">Meaning</th>
+</tr></thead>
+<tbody><tr id="_ead3a49f-e5ed-b5c4-3ff7-14111e892efa" semx-id="_ead3a49f-e5ed-b5c4-3ff7-14111e892efa"><td id="_adbf81ad-32cb-1ae9-aa4c-5ec38886a5e4" valign="top" align="left" semx-id="_adbf81ad-32cb-1ae9-aa4c-5ec38886a5e4">SPC</td>
+<td id="_2e98bcdf-b6f0-4740-f6d3-c5f4b5269816" valign="top" align="left" semx-id="_2e98bcdf-b6f0-4740-f6d3-c5f4b5269816">32</td>
+<td id="_5c14cebf-cedc-9e03-8b00-5169e03f5e76" valign="top" align="left" semx-id="_5c14cebf-cedc-9e03-8b00-5169e03f5e76">Separates keys and values in a table and surrounds infix operators</td>
+</tr><tr id="_acaeae75-5b57-b783-57b7-68fb2bdba73f" semx-id="_acaeae75-5b57-b783-57b7-68fb2bdba73f"><td id="_c126fee5-a61d-6cf3-b4ff-621b2ddadc9e" valign="top" align="left" semx-id="_c126fee5-a61d-6cf3-b4ff-621b2ddadc9e">TAB</td>
+<td id="_52ed1745-e2aa-a5b3-f0ac-4d6a4a4ee93b" valign="top" align="left" semx-id="_52ed1745-e2aa-a5b3-f0ac-4d6a4a4ee93b">9</td>
+<td id="_a34e1575-f04b-75a4-3d77-deab9b3d5624" valign="top" align="left" semx-id="_a34e1575-f04b-75a4-3d77-deab9b3d5624">Separates keys and values in a table and surrounds infix operators</td>
+</tr><tr id="_9e997154-2a20-32a3-ba16-4e3954c99988" semx-id="_9e997154-2a20-32a3-ba16-4e3954c99988"><td id="_7e62f211-16bf-f347-9f3b-69609fa8d9d6" valign="top" align="left" semx-id="_7e62f211-16bf-f347-9f3b-69609fa8d9d6"><tt>(</tt></td>
+<td id="_84f1792b-2676-adbb-4c04-e3bc7717cd5b" valign="top" align="left" semx-id="_84f1792b-2676-adbb-4c04-e3bc7717cd5b">40</td>
+<td id="_7a6c0baa-ca7e-0fa2-1cfa-e10c81e019e9" valign="top" align="left" semx-id="_7a6c0baa-ca7e-0fa2-1cfa-e10c81e019e9">Marks the start of the parameter list for interpolation functions</td>
+</tr><tr id="_6cfdd753-a0fc-0d87-6bc0-4f4da02ffd8e" semx-id="_6cfdd753-a0fc-0d87-6bc0-4f4da02ffd8e"><td id="_6fb5b334-32c4-19ec-36e7-d2dae5481f85" valign="top" align="left" semx-id="_6fb5b334-32c4-19ec-36e7-d2dae5481f85"><tt>)</tt></td>
+<td id="_36344f2f-1535-3d83-c10d-47347552fb4a" valign="top" align="left" semx-id="_36344f2f-1535-3d83-c10d-47347552fb4a">41</td>
+<td id="_5d0e9c9e-3a6d-e818-14b3-2e88a7b717c4" valign="top" align="left" semx-id="_5d0e9c9e-3a6d-e818-14b3-2e88a7b717c4">Marks the end of the parameter list for interpolation functions</td>
+</tr><tr id="_e5547300-316a-2970-f4ab-ddef8f3ac738" semx-id="_e5547300-316a-2970-f4ab-ddef8f3ac738"><td id="_3223113c-332a-6d7e-7c1d-7fd2df2cb7e2" valign="top" align="left" semx-id="_3223113c-332a-6d7e-7c1d-7fd2df2cb7e2"><tt>{</tt></td>
+<td id="_f806168c-5ef6-4f4c-f7f1-a39a8314c2f4" valign="top" align="left" semx-id="_f806168c-5ef6-4f4c-f7f1-a39a8314c2f4">123</td>
+<td id="_1a85737d-3228-5a34-0d19-468904c5219b" valign="top" align="left" semx-id="_1a85737d-3228-5a34-0d19-468904c5219b">Marks the start of a table value</td>
+</tr><tr id="_79c69a1f-a04d-4f15-b617-fdd43edcd83b" semx-id="_79c69a1f-a04d-4f15-b617-fdd43edcd83b"><td id="_14d56ac4-1358-4f68-d12f-d041453137bf" valign="top" align="left" semx-id="_14d56ac4-1358-4f68-d12f-d041453137bf"><tt>}</tt></td>
+<td id="_0bff8d69-9ba5-fe9d-7a7c-56ef0f1d644a" valign="top" align="left" semx-id="_0bff8d69-9ba5-fe9d-7a7c-56ef0f1d644a">125</td>
+<td id="_7a9d8461-2d75-8eec-6753-d04ba043ff41" valign="top" align="left" semx-id="_7a9d8461-2d75-8eec-6753-d04ba043ff41">Marks the end of a table value</td>
+</tr><tr id="_11210f2c-63fa-fd3b-750f-ed9408289402" semx-id="_11210f2c-63fa-fd3b-750f-ed9408289402"><td id="_f16f183e-f514-8db2-71e6-900529f27af7" valign="top" align="left" semx-id="_f16f183e-f514-8db2-71e6-900529f27af7"><tt>[</tt></td>
+<td id="_223ff3a7-7530-cae8-3a8f-ba53784c01ae" valign="top" align="left" semx-id="_223ff3a7-7530-cae8-3a8f-ba53784c01ae">91</td>
+<td id="_4bc7facb-eb83-de1a-0676-a3f72a1693fe" valign="top" align="left" semx-id="_4bc7facb-eb83-de1a-0676-a3f72a1693fe">Marks the start of a list value</td>
+</tr><tr id="_c5799070-2c3d-fa30-69da-410cd906ed0c" semx-id="_c5799070-2c3d-fa30-69da-410cd906ed0c"><td id="_22d40223-322e-9f7a-7dfd-9d5739104112" valign="top" align="left" semx-id="_22d40223-322e-9f7a-7dfd-9d5739104112"><tt>]</tt></td>
+<td id="_a117b926-77c5-56cc-86b8-f387d2f43b19" valign="top" align="left" semx-id="_a117b926-77c5-56cc-86b8-f387d2f43b19">93</td>
+<td id="_2ce6620e-32c8-e021-3001-ec949816cd22" valign="top" align="left" semx-id="_2ce6620e-32c8-e021-3001-ec949816cd22">Marks the end of a list value</td>
+</tr><tr id="_aef54180-787e-954a-6355-ce16baed8e8c" semx-id="_aef54180-787e-954a-6355-ce16baed8e8c"><td id="_19e6715e-343d-52b1-7c1b-761badccadff" valign="top" align="left" semx-id="_19e6715e-343d-52b1-7c1b-761badccadff"><tt>"</tt></td>
+<td id="_303d08ae-0003-a0c6-6439-f2a922d756ef" valign="top" align="left" semx-id="_303d08ae-0003-a0c6-6439-f2a922d756ef">34</td>
+<td id="_699bdd20-ce66-15ae-05da-4e6049ee304a" valign="top" align="left" semx-id="_699bdd20-ce66-15ae-05da-4e6049ee304a">Marks the start and end of a quoted string</td>
+</tr><tr id="_04a4b932-9392-381c-d33f-d1f7a278e04a" semx-id="_04a4b932-9392-381c-d33f-d1f7a278e04a"><td id="_cf1c316d-ff3b-9eae-4650-961515e42b29" valign="top" align="left" semx-id="_cf1c316d-ff3b-9eae-4650-961515e42b29"><tt>#</tt></td>
+<td id="_923d1d9b-6a1f-fc65-2a55-3bc256e622f9" valign="top" align="left" semx-id="_923d1d9b-6a1f-fc65-2a55-3bc256e622f9">35</td>
+<td id="_2c1e5b6b-5c53-782f-e41d-3300b828bd86" valign="top" align="left" semx-id="_2c1e5b6b-5c53-782f-e41d-3300b828bd86">Marks the beginning of a comment</td>
+</tr><tr id="_77cbfdee-83e5-c9c5-195d-543e5103279f" semx-id="_77cbfdee-83e5-c9c5-195d-543e5103279f"><td id="_9a7c3a17-ec4b-dddb-08fb-ab71662e0a85" valign="top" align="left" semx-id="_9a7c3a17-ec4b-dddb-08fb-ab71662e0a85"><tt>$</tt></td>
+<td id="_d4da542d-2f17-170b-353a-36d9aca05d15" valign="top" align="left" semx-id="_d4da542d-2f17-170b-353a-36d9aca05d15">36</td>
+<td id="_108e213a-2e60-1cba-68a3-44ab6fb6f83d" valign="top" align="left" semx-id="_108e213a-2e60-1cba-68a3-44ab6fb6f83d">Marks a template application without parameters</td>
+</tr><tr id="_d768455b-a37d-f4ef-576c-8caf129c2e5e" semx-id="_d768455b-a37d-f4ef-576c-8caf129c2e5e"><td id="_bb0bf5b6-6721-94d2-f23f-07a63045fca9" valign="top" align="left" semx-id="_bb0bf5b6-6721-94d2-f23f-07a63045fca9">CR</td>
+<td id="_25a5b214-5cd0-c09b-b84d-29a67259c81a" valign="top" align="left" semx-id="_25a5b214-5cd0-c09b-b84d-29a67259c81a">10</td>
+<td id="_59ac7496-fd06-4a77-03a4-d27fe17db371" valign="top" align="left" semx-id="_59ac7496-fd06-4a77-03a4-d27fe17db371">Separates entries within tables, lists and parameter lists</td>
+</tr><tr id="_88d156f6-b0ee-3ae6-9930-091056d33442" semx-id="_88d156f6-b0ee-3ae6-9930-091056d33442"><td id="_dcf103d8-9552-c671-73bc-5c6e68232673" valign="top" align="left" semx-id="_dcf103d8-9552-c671-73bc-5c6e68232673"><tt>,</tt></td>
+<td id="_3b527f99-6815-a3d6-16da-288d7bca9509" valign="top" align="left" semx-id="_3b527f99-6815-a3d6-16da-288d7bca9509">44</td>
+<td id="_dd467802-bed4-3c8c-6818-10767809fc2a" valign="top" align="left" semx-id="_dd467802-bed4-3c8c-6818-10767809fc2a">Separates entries within tables, lists and parameter lists</td>
+</tr><tr id="_f924dd6d-5d30-2162-90be-a41e040e18b2" semx-id="_f924dd6d-5d30-2162-90be-a41e040e18b2"><td id="_bb59a605-035f-14e0-2cde-366fe5cc2e5c" valign="top" align="left" semx-id="_bb59a605-035f-14e0-2cde-366fe5cc2e5c"><tt>\</tt></td>
+<td id="_0bd784dc-5ccb-4236-615a-c31c0c8f7a55" valign="top" align="left" semx-id="_0bd784dc-5ccb-4236-615a-c31c0c8f7a55">92</td>
+<td id="_fafe14ee-e846-5a6d-9f94-0f1245c34ad3" valign="top" align="left" semx-id="_fafe14ee-e846-5a6d-9f94-0f1245c34ad3">Indicates an escape sequence</td>
+</tr></tbody>
+</table>
+</clause>
+
+<clause id="_708fce8e-8204-98f4-2a2a-8b9eff256419" obligation="normative" semx-id="_708fce8e-8204-98f4-2a2a-8b9eff256419">
+<title id="_ae82fcb0-1797-6c05-c88c-5e1f5bc8c010" semx-id="_00542133-19a3-7712-a963-9ac03207185d">String</title><fmt-title depth="3" id="_e1b10c80-d23c-6bdb-62a6-6ac4e9389438"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_708fce8e-8204-98f4-2a2a-8b9eff256419">2</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_ae82fcb0-1797-6c05-c88c-5e1f5bc8c010">String</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_708fce8e-8204-98f4-2a2a-8b9eff256419">2</semx></fmt-xref-label>
+<p id="_d8006b1e-7668-ce4f-1966-7e9f99010be7" semx-id="_d8006b1e-7668-ce4f-1966-7e9f99010be7">Strings can be either bare or quoted. A bare string comprises one or more characters not listed in the ‘Special Characters’ section above.</p>
+
+<p id="_2ef94b2d-d1a5-5a6d-509c-a168509c925c" semx-id="_2ef94b2d-d1a5-5a6d-509c-a168509c925c">The following Special characters can be included within a bare string if they are escaped with the backslash (<tt>\</tt> ASCII 92) character.</p>
+
+<table id="_9e4827d1-ae0d-5679-1655-6a16c06d78cc" unnumbered="true" semx-id="_9e4827d1-ae0d-5679-1655-6a16c06d78cc"><thead><tr id="_910211f5-b7f3-975c-d4b1-18c763b61e80" semx-id="_910211f5-b7f3-975c-d4b1-18c763b61e80"><th id="_d65d364c-ce4f-eb8d-db67-748c20b49880" valign="top" align="left" semx-id="_d65d364c-ce4f-eb8d-db67-748c20b49880">Sequence</th>
+<th id="_a1028cb6-9f94-f388-0cb4-4f15cd00fe48" valign="top" align="left" semx-id="_a1028cb6-9f94-f388-0cb4-4f15cd00fe48">Meaning</th>
+<th id="_5de215f1-b186-443f-be14-cf0b1de3b716" valign="top" align="left" semx-id="_5de215f1-b186-443f-be14-cf0b1de3b716">ASCII</th>
+</tr></thead>
+<tbody><tr id="_47c27e4b-abd1-c038-528a-88e8357b7462" semx-id="_47c27e4b-abd1-c038-528a-88e8357b7462"><td id="_d09ac9b9-6135-faed-89cd-6fc08a2577d2" valign="top" align="left" semx-id="_d09ac9b9-6135-faed-89cd-6fc08a2577d2"><tt>\(</tt></td>
+<td id="_9b5a12e6-8a33-96fe-dbb7-24e7b49669b2" valign="top" align="left" semx-id="_9b5a12e6-8a33-96fe-dbb7-24e7b49669b2">Open brace</td>
+<td id="_4e31d87e-c1cd-a32d-6d61-86dd3eddca26" valign="top" align="left" semx-id="_4e31d87e-c1cd-a32d-6d61-86dd3eddca26">40</td>
+</tr><tr id="_8932723d-2b81-4747-b3f5-970a81dde655" semx-id="_8932723d-2b81-4747-b3f5-970a81dde655"><td id="_0484472e-20e8-b5d2-b4fb-44c075819af0" valign="top" align="left" semx-id="_0484472e-20e8-b5d2-b4fb-44c075819af0"><tt>\)</tt></td>
+<td id="_1dc1cea6-cfe1-5094-fa93-537b3e6d66bf" valign="top" align="left" semx-id="_1dc1cea6-cfe1-5094-fa93-537b3e6d66bf">Close brace</td>
+<td id="_d02edd54-1aae-cf1a-b7bd-0dc671379c95" valign="top" align="left" semx-id="_d02edd54-1aae-cf1a-b7bd-0dc671379c95">41</td>
+</tr><tr id="_354191a5-9151-9fc0-f004-f233a6ec62c6" semx-id="_354191a5-9151-9fc0-f004-f233a6ec62c6"><td id="_f3db5859-9350-3aa4-f82a-9050f0210965" valign="top" align="left" semx-id="_f3db5859-9350-3aa4-f82a-9050f0210965"><tt>\{</tt></td>
+<td id="_5bc0dc73-9343-76f9-a0b0-dd8b2241a5fa" valign="top" align="left" semx-id="_5bc0dc73-9343-76f9-a0b0-dd8b2241a5fa">Open curly brace</td>
+<td id="_db806d15-0b9a-ceeb-eeef-33d89fb82a11" valign="top" align="left" semx-id="_db806d15-0b9a-ceeb-eeef-33d89fb82a11">123</td>
+</tr><tr id="_a6e5c9df-e167-466a-c78b-9be9a96dae88" semx-id="_a6e5c9df-e167-466a-c78b-9be9a96dae88"><td id="_538e5d0c-8ca0-e2ce-3b92-8c0981b34b1d" valign="top" align="left" semx-id="_538e5d0c-8ca0-e2ce-3b92-8c0981b34b1d"><tt>\}</tt></td>
+<td id="_5e649eef-dc96-538c-d069-aee971948e1e" valign="top" align="left" semx-id="_5e649eef-dc96-538c-d069-aee971948e1e">Close curly brace</td>
+<td id="_908f2e85-3e60-5a34-b19b-b7d49846ff6d" valign="top" align="left" semx-id="_908f2e85-3e60-5a34-b19b-b7d49846ff6d">125</td>
+</tr><tr id="_a877ca7c-5b45-691f-a554-664342fc5c39" semx-id="_a877ca7c-5b45-691f-a554-664342fc5c39"><td id="_30785b67-3957-de5b-741b-f9f0d1efb7c3" valign="top" align="left" semx-id="_30785b67-3957-de5b-741b-f9f0d1efb7c3"><tt>\[</tt></td>
+<td id="_6f2e31c0-313a-3d77-4584-eeee071cfc35" valign="top" align="left" semx-id="_6f2e31c0-313a-3d77-4584-eeee071cfc35">Open square brace</td>
+<td id="_f18b8d58-0b9c-58d7-0296-4c8eb70f3325" valign="top" align="left" semx-id="_f18b8d58-0b9c-58d7-0296-4c8eb70f3325">91</td>
+</tr><tr id="_779a1269-1aae-fa5a-c7af-49ce016df643" semx-id="_779a1269-1aae-fa5a-c7af-49ce016df643"><td id="_b4871348-2b4a-d9f6-8c58-8786a49f5f36" valign="top" align="left" semx-id="_b4871348-2b4a-d9f6-8c58-8786a49f5f36"><tt>\]</tt></td>
+<td id="_a864c120-50eb-819c-4449-4f02bed664f2" valign="top" align="left" semx-id="_a864c120-50eb-819c-4449-4f02bed664f2">Close square brace</td>
+<td id="_72a83bdc-dcb8-a941-1125-bd848c382103" valign="top" align="left" semx-id="_72a83bdc-dcb8-a941-1125-bd848c382103">93</td>
+</tr><tr id="_f3fa849b-bcfb-0070-cd85-3f3ec3c10eba" semx-id="_f3fa849b-bcfb-0070-cd85-3f3ec3c10eba"><td id="_a4d30267-d6c2-2a9d-feac-84e53c982ef5" valign="top" align="left" semx-id="_a4d30267-d6c2-2a9d-feac-84e53c982ef5"><tt>\#</tt></td>
+<td id="_b335e19b-1f6e-69ae-b2b4-fb99befae072" valign="top" align="left" semx-id="_b335e19b-1f6e-69ae-b2b4-fb99befae072">Hash sign</td>
+<td id="_2645c242-6085-c2be-8667-e207d72b371e" valign="top" align="left" semx-id="_2645c242-6085-c2be-8667-e207d72b371e">35</td>
+</tr><tr id="_916031b9-5ee5-735f-cf75-7945bf8315ad" semx-id="_916031b9-5ee5-735f-cf75-7945bf8315ad"><td id="_dde75ead-57d2-ef97-d493-433c3e1eacfb" valign="top" align="left" semx-id="_dde75ead-57d2-ef97-d493-433c3e1eacfb"><tt>\$</tt></td>
+<td id="_ebfd6fcb-2875-7158-b014-12b686293de2" valign="top" align="left" semx-id="_ebfd6fcb-2875-7158-b014-12b686293de2">Dollar sign</td>
+<td id="_425ec871-6515-6aab-a7b3-a34b516bfc67" valign="top" align="left" semx-id="_425ec871-6515-6aab-a7b3-a34b516bfc67">35</td>
+</tr><tr id="_dfc9efab-a044-f573-904e-d155b3cbefcc" semx-id="_dfc9efab-a044-f573-904e-d155b3cbefcc"><td id="_bfa37a8e-0c20-cbc8-bb78-60e69de064ef" valign="top" align="left" semx-id="_bfa37a8e-0c20-cbc8-bb78-60e69de064ef"><tt>\,</tt></td>
+<td id="_ff200bb7-12ab-e287-6df5-15def9784043" valign="top" align="left" semx-id="_ff200bb7-12ab-e287-6df5-15def9784043">Comma</td>
+<td id="_c74b774c-3f01-8fef-3f60-51f22fbd7d99" valign="top" align="left" semx-id="_c74b774c-3f01-8fef-3f60-51f22fbd7d99">44</td>
+</tr><tr id="_1f6cdcf8-394c-7ea3-ce88-abf6ea4a9079" semx-id="_1f6cdcf8-394c-7ea3-ce88-abf6ea4a9079"><td id="_b0a4de1d-679c-4ac3-f5b0-f491c04e28e2" valign="top" align="left" semx-id="_b0a4de1d-679c-4ac3-f5b0-f491c04e28e2">`\ `</td>
+<td id="_3330da8e-9a95-af23-2ba5-df5fe3995016" valign="top" align="left" semx-id="_3330da8e-9a95-af23-2ba5-df5fe3995016">Space</td>
+<td id="_8f6477c7-958f-07bc-a46d-cf4e0062deef" valign="top" align="left" semx-id="_8f6477c7-958f-07bc-a46d-cf4e0062deef">32</td>
+</tr></tbody>
+</table>
+
+<p id="_b0692c68-083f-b132-01c8-38bfb8d04bf1" semx-id="_b0692c68-083f-b132-01c8-38bfb8d04bf1">Quoted strings are enclosed in double quotation marks (<tt>"</tt> ASCII 34) and may contain any of the  <tt>Special Characters</tt> above with the exception of  <tt>\</tt> (ASCII 92) and <tt>"</tt> (ASCII 34). <tt>\</tt> and <tt>"</tt> must always be escaped.</p>
+
+<p id="_9d697b50-1af4-eb67-60a7-591b424ed49c" semx-id="_9d697b50-1af4-eb67-60a7-591b424ed49c">The following escape sequences are recognised in both bare and quoted strings:</p>
+
+<table id="_e6e78421-5750-7ffa-3a70-be8c447baa2d" unnumbered="true" semx-id="_e6e78421-5750-7ffa-3a70-be8c447baa2d"><thead><tr id="_e1fcb3d4-d2c7-d3b9-44d7-00c5bfc64cf0" semx-id="_e1fcb3d4-d2c7-d3b9-44d7-00c5bfc64cf0"><th id="_9e324540-f7ba-d504-9553-b283e68bbf3d" valign="top" align="left" semx-id="_9e324540-f7ba-d504-9553-b283e68bbf3d">Escape Sequence</th>
+<th id="_38b64c51-d9be-4dca-8bee-679576353e0e" valign="top" align="left" semx-id="_38b64c51-d9be-4dca-8bee-679576353e0e">ASCII</th>
+<th id="_eb637897-a12a-5ff3-e202-476f251c4a87" valign="top" align="left" semx-id="_eb637897-a12a-5ff3-e202-476f251c4a87">Character represented</th>
+</tr></thead>
+<tbody><tr id="_ab959f33-429e-515c-791c-0ce7cc85ce13" semx-id="_ab959f33-429e-515c-791c-0ce7cc85ce13"><td id="_09854331-4ce1-cb2e-3217-deadc8134058" valign="top" align="left" semx-id="_09854331-4ce1-cb2e-3217-deadc8134058">\n</td>
+<td id="_dbb67bb1-5d5e-04a8-72f2-344766d588dc" valign="top" align="left" semx-id="_dbb67bb1-5d5e-04a8-72f2-344766d588dc">10</td>
+<td id="_a62279f2-62b7-5ae7-1408-32c31fbf233d" valign="top" align="left" semx-id="_a62279f2-62b7-5ae7-1408-32c31fbf233d">Newline (Line Feed)</td>
+</tr><tr id="_af16639b-74b0-d09f-d347-3fe3a710f97e" semx-id="_af16639b-74b0-d09f-d347-3fe3a710f97e"><td id="_bb4767ad-5ce2-049c-46f6-0bf6018a2ac9" valign="top" align="left" semx-id="_bb4767ad-5ce2-049c-46f6-0bf6018a2ac9">\r</td>
+<td id="_507bf3dc-d226-fda7-1cc4-65af56b5fae9" valign="top" align="left" semx-id="_507bf3dc-d226-fda7-1cc4-65af56b5fae9">13</td>
+<td id="_fa6ba183-a324-a5d6-65cd-5ea41b531e63" valign="top" align="left" semx-id="_fa6ba183-a324-a5d6-65cd-5ea41b531e63">Carriage Return</td>
+</tr><tr id="_24fb24b0-c77a-69d4-e366-6576db4ac363" semx-id="_24fb24b0-c77a-69d4-e366-6576db4ac363"><td id="_ce1ab7b4-eabb-da75-5f8e-6f2d7e309f0c" valign="top" align="left" semx-id="_ce1ab7b4-eabb-da75-5f8e-6f2d7e309f0c">\t</td>
+<td id="_a8a6b444-09d4-7da9-5f32-17e1909854e9" valign="top" align="left" semx-id="_a8a6b444-09d4-7da9-5f32-17e1909854e9">9</td>
+<td id="_9c888ef5-025c-2edd-1614-b0ec3d65cef0" valign="top" align="left" semx-id="_9c888ef5-025c-2edd-1614-b0ec3d65cef0">Horizontal Tab</td>
+</tr><tr id="_28dd584e-22fa-f95d-6402-aa60fc38e7f9" semx-id="_28dd584e-22fa-f95d-6402-aa60fc38e7f9"><td id="_77e428bc-2c75-dcf8-9d97-53367f2ec455" valign="top" align="left" semx-id="_77e428bc-2c75-dcf8-9d97-53367f2ec455">\\</td>
+<td id="_81fc2584-c124-e5ce-c243-dafbb1b9f69c" valign="top" align="left" semx-id="_81fc2584-c124-e5ce-c243-dafbb1b9f69c">92</td>
+<td id="_795c9b1c-26e5-3862-821f-eed7ed72cc63" valign="top" align="left" semx-id="_795c9b1c-26e5-3862-821f-eed7ed72cc63">Backslash</td>
+</tr><tr id="_21a77fea-ec66-dcfc-aee3-75ffcfcb8b26" semx-id="_21a77fea-ec66-dcfc-aee3-75ffcfcb8b26"><td id="_bf9640ed-eb30-3cba-257c-1a3c8d506ae7" valign="top" align="left" semx-id="_bf9640ed-eb30-3cba-257c-1a3c8d506ae7">\’</td>
+<td id="_e712dda4-852a-d8d2-d724-6ac39ef529ac" valign="top" align="left" semx-id="_e712dda4-852a-d8d2-d724-6ac39ef529ac">39</td>
+<td id="_ef0a079f-b9a3-5aa2-8cf1-c04915bd958e" valign="top" align="left" semx-id="_ef0a079f-b9a3-5aa2-8cf1-c04915bd958e">Single quotation mark</td>
+</tr><tr id="_7d4d9c47-d13a-a6ad-982d-b704e045b45d" semx-id="_7d4d9c47-d13a-a6ad-982d-b704e045b45d"><td id="_84e25eb0-475b-4674-8196-4fb1cc4eab55" valign="top" align="left" semx-id="_84e25eb0-475b-4674-8196-4fb1cc4eab55">\”</td>
+<td id="_87e34cfb-3a50-db5d-3137-ff648b70292c" valign="top" align="left" semx-id="_87e34cfb-3a50-db5d-3137-ff648b70292c">34</td>
+<td id="_7daae009-9a59-cb30-812d-23890d7292ee" valign="top" align="left" semx-id="_7daae009-9a59-cb30-812d-23890d7292ee">Double quotation mark</td>
+</tr><tr id="_6c9bed47-a241-4974-81ce-7bb4eeeb146b" semx-id="_6c9bed47-a241-4974-81ce-7bb4eeeb146b"><td id="_58e5ae6c-a4e7-c8ab-b219-003964d5d908" valign="top" align="left" semx-id="_58e5ae6c-a4e7-c8ab-b219-003964d5d908">\0nn</td>
+<td id="_cec98875-0dd8-34ea-3abd-b966d1fa899b" valign="top" align="left" semx-id="_cec98875-0dd8-34ea-3abd-b966d1fa899b">any</td>
+<td id="_7aea7f8a-8ae3-a3b5-d38e-50a1b19ac6e5" valign="top" align="left" semx-id="_7aea7f8a-8ae3-a3b5-d38e-50a1b19ac6e5">The byte whose numerical value is given by 0nn interpreted as an octal number</td>
+</tr><tr id="_a26b3451-48e7-52b8-bd96-8129113e361b" semx-id="_a26b3451-48e7-52b8-bd96-8129113e361b"><td id="_5fc1e004-1bef-1b4f-215f-ed91268f5b4e" valign="top" align="left" semx-id="_5fc1e004-1bef-1b4f-215f-ed91268f5b4e">\xhh</td>
+<td id="_408dd67b-6440-6423-cef6-1917bae04ae4" valign="top" align="left" semx-id="_408dd67b-6440-6423-cef6-1917bae04ae4">any</td>
+<td id="_c044202a-98a2-d607-831d-f7bc8a8994b5" valign="top" align="left" semx-id="_c044202a-98a2-d607-831d-f7bc8a8994b5">The byte whose numerical value is given by hh interpreted as a hexadecimal number</td>
+</tr><tr id="_c93ba6bb-bf39-a8b8-4b7d-1f26bd4bc345" semx-id="_c93ba6bb-bf39-a8b8-4b7d-1f26bd4bc345"><td id="_1d46f80b-2008-4faf-10ba-8ecca71555ca" valign="top" align="left" semx-id="_1d46f80b-2008-4faf-10ba-8ecca71555ca">\Uhhhhhhhh</td>
+<td id="_5f58740c-4f5e-9da0-bb61-099850b318c2" valign="top" align="left" semx-id="_5f58740c-4f5e-9da0-bb61-099850b318c2">none</td>
+<td id="_37f90db3-fb1a-bae8-8ee4-aced2a18052a" valign="top" align="left" semx-id="_37f90db3-fb1a-bae8-8ee4-aced2a18052a">Unicode code point where h is a hexadecimal digit</td>
+</tr><tr id="_5bddaf67-4aed-1aab-e173-a9c0f2d4385d" semx-id="_5bddaf67-4aed-1aab-e173-a9c0f2d4385d"><td id="_d9bea881-5263-227d-2c15-1cb33f8b67ff" valign="top" align="left" semx-id="_d9bea881-5263-227d-2c15-1cb33f8b67ff">\uhhhh</td>
+<td id="_96897921-d050-2ba1-f049-0134829803b1" valign="top" align="left" semx-id="_96897921-d050-2ba1-f049-0134829803b1">none</td>
+<td id="_f150c336-bb6e-c693-d76b-779c001e5353" valign="top" align="left" semx-id="_f150c336-bb6e-c693-d76b-779c001e5353">Unicode code point below 10000 hexadecimal</td>
+</tr></tbody>
+</table>
+
+<p id="_9e5f1d31-ee77-55f6-6394-051c9bf9021d" semx-id="_9e5f1d31-ee77-55f6-6394-051c9bf9021d">Multi-line strings are permitted as long as they are quoted.</p>
+
+<p id="_9c14aacc-c6a0-ba0b-8ca8-3cc1d2b98a72" semx-id="_9c14aacc-c6a0-ba0b-8ca8-3cc1d2b98a72">Examples:</p>
+
+<sourcecode id="_ad95c11b-1b17-c0f3-8164-b6807e6a88c5" unnumbered="true" semx-id="_ad95c11b-1b17-c0f3-8164-b6807e6a88c5"><body>"The Rachel Papers"
+Success
+Money
+"Time's Arrow"</body><fmt-sourcecode unnumbered="true" semx-id="_ad95c11b-1b17-c0f3-8164-b6807e6a88c5" id="_0de61536-086e-892a-49af-4c7d75ef8908">"The Rachel Papers"
+Success
+Money
+"Time's Arrow"</fmt-sourcecode></sourcecode>
+
+</clause>
+
+<clause id="_8917cf62-9d8a-f6e9-5187-e2e5ed77edcc" obligation="normative" semx-id="_8917cf62-9d8a-f6e9-5187-e2e5ed77edcc">
+<title id="_2059a0d4-18fc-0f87-7413-9448ae2062b2" semx-id="_cde2cb10-403b-b77e-604f-a010893282d3">List</title><fmt-title depth="3" id="_3cf33977-8edb-c5d3-22d7-498743a6dc85"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_8917cf62-9d8a-f6e9-5187-e2e5ed77edcc">3</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_2059a0d4-18fc-0f87-7413-9448ae2062b2">List</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_8917cf62-9d8a-f6e9-5187-e2e5ed77edcc">3</semx></fmt-xref-label>
+<p id="_ae4149e8-ff60-aeba-cebf-47b9174b8b4c" semx-id="_ae4149e8-ff60-aeba-cebf-47b9174b8b4c">A list is an ordered set of values. Lists are enclosed in square braces (<tt>[]</tt> ASCII 91/93). Within the braces are zero or more values separated by one or more comma (<tt>,</tt> ASCII 44) or newline (ASCII 10) characters. Values are numbered, starting at zero. Numbers are assigned to each value in the order in which they are defined.</p>
+
+<p id="_6acd39fe-2539-a4c6-0647-1c5735f48528" semx-id="_6acd39fe-2539-a4c6-0647-1c5735f48528">Example:</p>
+
+<sourcecode id="_7425a540-3b5d-e761-2e9b-5e00b830a0c2" unnumbered="true" semx-id="_7425a540-3b5d-e761-2e9b-5e00b830a0c2"><body>[
+    Aglovale, Breunor, Claudin
+    Calogrenant, Dinadan, "Elyan the White"
+
+    Erec, Galeschin, Gornemant,
+    "Hector de Maris", Lucan,
+    "Meliant de Lis", Morholt
+    Safir, Segwarides, Tor
+]</body><fmt-sourcecode unnumbered="true" semx-id="_7425a540-3b5d-e761-2e9b-5e00b830a0c2" id="_874c2a98-e68c-4070-a809-e5f1f81935b6">[
+    Aglovale, Breunor, Claudin
+    Calogrenant, Dinadan, "Elyan the White"
+
+    Erec, Galeschin, Gornemant,
+    "Hector de Maris", Lucan,
+    "Meliant de Lis", Morholt
+    Safir, Segwarides, Tor
+]</fmt-sourcecode></sourcecode>
+
+</clause>
+
+<clause id="_0b132810-e7c4-b602-9540-9aa54d9b0a16" obligation="normative" semx-id="_0b132810-e7c4-b602-9540-9aa54d9b0a16">
+<title id="_2d1749df-6eda-9ec6-d0d8-5109f9e1ba23" semx-id="_f865e435-bf8b-30c1-db32-5f8c52e8c057">Table</title><fmt-title depth="3" id="_c493587e-cf3c-f455-0588-db2318049d8d"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_0b132810-e7c4-b602-9540-9aa54d9b0a16">4</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_2d1749df-6eda-9ec6-d0d8-5109f9e1ba23">Table</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_0b132810-e7c4-b602-9540-9aa54d9b0a16">4</semx></fmt-xref-label>
+<p id="_6cb4a00a-f4e4-30e7-4dcc-255bdfc6ee2d" semx-id="_6cb4a00a-f4e4-30e7-4dcc-255bdfc6ee2d">A table is an unordered set of key and value pairs. A table is enclosed in curly braces (<tt>{}</tt> ASCII 123/125). Within the braces are zero or more key/value pairs. Pairs are separated by one or more comma (<tt>,</tt> ASCII 44) or newline (ASCII 10) characters. Keys are strings. Table entries are defined by specifying a key and a value separated by any combination of space (` ` ASCII 32) and tab (\t` ASCII 9) characters. Keys are unique with a table. If a key appears more than once in a table definition the last value is the only one retained by the table.</p>
+
+<p id="_b146a7f5-e613-0956-1f1a-0cfc0d08669a" semx-id="_b146a7f5-e613-0956-1f1a-0cfc0d08669a">Example:</p>
+
+<sourcecode id="_429a062e-775e-6af5-9530-2794fb843b31" unnumbered="true" semx-id="_429a062e-775e-6af5-9530-2794fb843b31"><body>contact {
+    name "John Doe"
+    email {
+        work "john.doe@work.domain"
+        home "john@home.domain"
+    }
+}</body><fmt-sourcecode unnumbered="true" semx-id="_429a062e-775e-6af5-9530-2794fb843b31" id="_1a0c5181-0c7c-15a9-0e51-d358b11fd54f">contact {
+    name "John Doe"
+    email {
+        work "john.doe@work.domain"
+        home "john@home.domain"
+    }
+}</fmt-sourcecode></sourcecode>
+
+
+<p id="_9656ba94-4a87-a5a7-98dc-fde05bda649a" semx-id="_9656ba94-4a87-a5a7-98dc-fde05bda649a">An additional syntax is defined for table entries where multiple keys precede the value. This syntax is only permitted within a table value and has the effect of recursively defining implicit nested table values with the initial keys. The final key and the value are used to create an entry within the most deeply nested table value. Using this syntax the above example can be written as:</p>
+
+<sourcecode id="_28437178-902d-a951-bdc0-565d12917299" unnumbered="true" semx-id="_28437178-902d-a951-bdc0-565d12917299"><body>contact {
+    name "John Doe"
+    email work "john.doe@work.domain"
+    email home "john@home.domain"
+}</body><fmt-sourcecode unnumbered="true" semx-id="_28437178-902d-a951-bdc0-565d12917299" id="_79d2514a-1892-67c4-cdb8-04bc1fc65660">contact {
+    name "John Doe"
+    email work "john.doe@work.domain"
+    email home "john@home.domain"
+}</fmt-sourcecode></sourcecode>
+
+
+<p id="_fde1ff12-8a48-2932-8f00-2219b09878cc" semx-id="_fde1ff12-8a48-2932-8f00-2219b09878cc">or</p>
+
+<sourcecode id="_61cc080f-c055-7042-694f-f63e37aa1c14" unnumbered="true" semx-id="_61cc080f-c055-7042-694f-f63e37aa1c14"><body>contact name "John Doe"
+contact email work "john.doe@work.domain"
+contact email home "john@home.domain"</body><fmt-sourcecode unnumbered="true" semx-id="_61cc080f-c055-7042-694f-f63e37aa1c14" id="_a352891f-d0ee-e6bb-c066-c11b963d28d0">contact name "John Doe"
+contact email work "john.doe@work.domain"
+contact email home "john@home.domain"</fmt-sourcecode></sourcecode>
+
+</clause>
+
+<clause id="_c0e7d504-2c3f-59f8-f8ea-7e464a2965cc" obligation="normative" semx-id="_c0e7d504-2c3f-59f8-f8ea-7e464a2965cc">
+<title id="_c4914fca-77d2-a729-3d06-00db6d61b40e" semx-id="_accb12e7-6fd8-8f27-d741-50c5b9f34546">Comment</title><fmt-title depth="3" id="_0d57e084-bba2-e172-a76f-b968bcfd925c"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c0e7d504-2c3f-59f8-f8ea-7e464a2965cc">5</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_c4914fca-77d2-a729-3d06-00db6d61b40e">Comment</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c6f4555a-411f-4c4c-0d60-d26f1e7166a0">1</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_c0e7d504-2c3f-59f8-f8ea-7e464a2965cc">5</semx></fmt-xref-label>
+<p id="_55074365-4994-afd0-af86-0465587bdf35" semx-id="_55074365-4994-afd0-af86-0465587bdf35">The hash (<tt>#</tt> ASCII 35) character indicates a comment which runs up to the next CR (<tt>\n</tt> ASCII 10).</p>
+</clause>
+</clause>
+
+<clause id="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7" obligation="normative" semx-id="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">
+<title id="_f8841a78-7c17-1414-c086-84f1f64d9d22" semx-id="_027e3811-9568-5229-1119-a04a514a0e29">Interpolation</title><fmt-title depth="2" id="_59d340bb-c8d8-a1dc-71fa-4fc4aa165a16"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">2</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_f8841a78-7c17-1414-c086-84f1f64d9d22">Interpolation</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">2</semx></fmt-xref-label>
+<p id="_cca047f8-05b0-2b97-7d45-965b8beb7a7d" semx-id="_cca047f8-05b0-2b97-7d45-965b8beb7a7d">Values are interpolated when a NON document is parsed.</p>
+
+<clause id="_05274b57-2c37-02db-6ec5-d75f9aecf62d" obligation="normative" semx-id="_05274b57-2c37-02db-6ec5-d75f9aecf62d">
+<title id="_8c54d823-8b4d-2b43-418c-d526a727d451" semx-id="_6bd0ebd7-497e-6ddf-47a2-ae16fb509569">Arithmetic interpolation</title><fmt-title depth="3" id="_be53f8cc-f1e4-b91e-40d1-c8b015c0e3bd"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">2</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_05274b57-2c37-02db-6ec5-d75f9aecf62d">1</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_8c54d823-8b4d-2b43-418c-d526a727d451">Arithmetic interpolation</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">2</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_05274b57-2c37-02db-6ec5-d75f9aecf62d">1</semx></fmt-xref-label>
+<p id="_a974ab33-cb49-c6d7-a6d4-b8abeda951ae" semx-id="_a974ab33-cb49-c6d7-a6d4-b8abeda951ae">Simple arithmetic is supported with the binary operators <tt>-</tt>, <tt>+</tt>, <tt>*</tt>, <tt>/</tt>, <tt>\</tt>, <tt>%</tt> and <tt>^</tt>. Binary operators must appear between to values and must be surrounded by one or more space (ASCII 32) or tab (ASCII 9) characters. The operators correspond respectively with the functions  <tt>subtract()</tt>, <tt>add()</tt>, <tt>multiply()</tt>, <tt>divide()</tt>, <tt>intdiv()</tt>, <tt>modulus()</tt> and <tt>power()</tt> described below.</p>
+
+<sourcecode id="_28aee2c6-edcd-eee4-f50e-90b9d2aec9bc" unnumbered="true" semx-id="_28aee2c6-edcd-eee4-f50e-90b9d2aec9bc"><body>port 8000 + 80 # port "8080"
+port 8000+80 # port "8000+80", probably not intentional!</body><fmt-sourcecode unnumbered="true" semx-id="_28aee2c6-edcd-eee4-f50e-90b9d2aec9bc" id="_2d37e662-56e4-f6df-6207-69bf51ad4c44">port 8000 + 80 # port "8080"
+port 8000+80 # port "8000+80", probably not intentional!</fmt-sourcecode></sourcecode>
+
+</clause>
+
+<clause id="_d8beec4b-7b24-025f-a351-ed8c3443af9b" obligation="normative" semx-id="_d8beec4b-7b24-025f-a351-ed8c3443af9b">
+<title id="_e0a13472-87e9-27bd-e6f3-319329b92718" semx-id="_d0eae921-eea5-06ed-163f-bd7494b1541a">Template interpolation</title><fmt-title depth="3" id="_1f248dfc-af7c-c735-700c-65cd5f5cce00"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">2</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_d8beec4b-7b24-025f-a351-ed8c3443af9b">2</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_e0a13472-87e9-27bd-e6f3-319329b92718">Template interpolation</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">2</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_d8beec4b-7b24-025f-a351-ed8c3443af9b">2</semx></fmt-xref-label>
+<p id="_f5615970-4fc9-05bd-cbd2-dfb944a61c29" semx-id="_f5615970-4fc9-05bd-cbd2-dfb944a61c29">Template values can be defined with the <tt>let()</tt> construct and reused later on in the document. Template values may or may not accept arguments which will affect their expansion.</p>
+
+<p id="_7b61b816-9d62-37dd-9a15-62b992daafe2" semx-id="_7b61b816-9d62-37dd-9a15-62b992daafe2">Within a template, arguments can be extracted using the <tt>arg(n)</tt> construct where  <tt>n</tt> is the zero-based argument index.</p>
+
+<p id="_a9ff89ab-a440-1a95-6e1e-47d25bb21aad" semx-id="_a9ff89ab-a440-1a95-6e1e-47d25bb21aad">Templates are applied by using the <tt>apply()</tt> construct. Templates without arguments can be applied using a special  <tt>$name</tt> construct which is syntactic sugar for  <tt>apply(name)</tt>.</p>
+
+<sourcecode id="_099f3bdb-c0ee-177b-e42b-b2fea37da970" unnumbered="true" semx-id="_099f3bdb-c0ee-177b-e42b-b2fea37da970"><body>let(base_port, 8000)
+let(port, $base_port + arg(0))
+
+port1 apply(port(80)) # port 8080
+port2 apply(port(81)) # port 8081
+port3 $base_port + 82 #port 8082</body><fmt-sourcecode unnumbered="true" semx-id="_099f3bdb-c0ee-177b-e42b-b2fea37da970" id="_a493605f-a648-ee88-3012-afc7aaf29524">let(base_port, 8000)
+let(port, $base_port + arg(0))
+
+port1 apply(port(80)) # port 8080
+port2 apply(port(81)) # port 8081
+port3 $base_port + 82 #port 8082</fmt-sourcecode></sourcecode>
+
+</clause>
+
+<clause id="_013480b5-f084-ab83-1c45-5cc427b99408" obligation="normative" semx-id="_013480b5-f084-ab83-1c45-5cc427b99408">
+<title id="_5871aa91-0120-2a6b-d81c-b637132f8838" semx-id="_8d41077e-2e87-a89a-57ed-8c3539a3fc96">Functions</title><fmt-title depth="3" id="_05144c30-4ef2-7169-993a-9613e357fbf1"><span class="fmt-caption-label"><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">2</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_013480b5-f084-ab83-1c45-5cc427b99408">3</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_5871aa91-0120-2a6b-d81c-b637132f8838">Functions</semx></fmt-title><fmt-xref-label><semx element="autonum" source="syntax">4</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_9acca574-4e07-cf9e-3db8-a2b1edf00bf7">2</semx><span class="fmt-autonum-delim">.</span><semx element="autonum" source="_013480b5-f084-ab83-1c45-5cc427b99408">3</semx></fmt-xref-label>
+<p id="_4c5be007-fd2b-38ce-e921-e55384c75f85" semx-id="_4c5be007-fd2b-38ce-e921-e55384c75f85">NON uses the <tt>name(args)</tt> construct for functions where name is a bare string and args is a comma separated list of zero or more arguments each of which is a valid NON value. The correct number of arguments will vary depending on the function.</p>
+
+<p id="_29ae98e4-d794-373e-2e20-0a9af4702e90" semx-id="_29ae98e4-d794-373e-2e20-0a9af4702e90">A NON parser supports at least the following basic functions:</p>
+
+<table id="_680290fd-a746-9d3a-d6ce-b6a1be58f717" unnumbered="true" semx-id="_680290fd-a746-9d3a-d6ce-b6a1be58f717"><thead><tr id="_20baa70a-b17d-20b8-c0a8-cf471234028e" semx-id="_20baa70a-b17d-20b8-c0a8-cf471234028e"><th id="_9306d166-ba5c-8d3d-b8cd-92fee9d9ab7b" valign="top" align="left" semx-id="_9306d166-ba5c-8d3d-b8cd-92fee9d9ab7b">Function</th>
+<th id="_5a48a911-1812-1090-3673-4df691b5d082" valign="top" align="left" semx-id="_5a48a911-1812-1090-3673-4df691b5d082">Result</th>
+</tr></thead>
+<tbody><tr id="_e5974a68-1fcf-85d3-4d54-32f6a2edf204" semx-id="_e5974a68-1fcf-85d3-4d54-32f6a2edf204"><td id="_c41ce83b-2eaa-32e4-cde7-598337250f9f" valign="top" align="left" semx-id="_c41ce83b-2eaa-32e4-cde7-598337250f9f"><tt>add(a, b)</tt></td>
+<td id="_a9eb84f1-13ee-b52a-86f2-bbe0cbe7ceba" valign="top" align="left" semx-id="_a9eb84f1-13ee-b52a-86f2-bbe0cbe7ceba">a + b</td>
+</tr><tr id="_5e27f084-5e05-262e-6d26-3e884ecefb05" semx-id="_5e27f084-5e05-262e-6d26-3e884ecefb05"><td id="_2e339ddc-2e5f-edc5-0d8c-ae2cd225707f" valign="top" align="left" semx-id="_2e339ddc-2e5f-edc5-0d8c-ae2cd225707f"><tt>subtract(a, b)</tt></td>
+<td id="_fcf0a41b-0604-527c-a04b-99f8a933b2ee" valign="top" align="left" semx-id="_fcf0a41b-0604-527c-a04b-99f8a933b2ee">a — b</td>
+</tr><tr id="_9f046340-6c8f-e28d-336a-6f05c21aca66" semx-id="_9f046340-6c8f-e28d-336a-6f05c21aca66"><td id="_02c28796-d31d-b754-fbda-8aaa989b9c30" valign="top" align="left" semx-id="_02c28796-d31d-b754-fbda-8aaa989b9c30"><tt>multiply(a, b)</tt></td>
+<td id="_0f640976-07a9-a183-d1d9-493d00b9e7cd" valign="top" align="left" semx-id="_0f640976-07a9-a183-d1d9-493d00b9e7cd">a × b</td>
+</tr><tr id="_fc583d1d-b093-0346-885f-db767f854278" semx-id="_fc583d1d-b093-0346-885f-db767f854278"><td id="_c3f9d3cb-7847-7899-e69f-bffcabbf42a1" valign="top" align="left" semx-id="_c3f9d3cb-7847-7899-e69f-bffcabbf42a1"><tt>divide(a, b)</tt></td>
+<td id="_eb631fb3-7ec6-fb1a-2872-2bc7bc012d46" valign="top" align="left" semx-id="_eb631fb3-7ec6-fb1a-2872-2bc7bc012d46">a ÷ b</td>
+</tr><tr id="_e87eb312-3b35-66de-74e4-8bcb2df1b449" semx-id="_e87eb312-3b35-66de-74e4-8bcb2df1b449"><td id="_9e3b7c70-0b84-b484-c6e4-b59a454ed669" valign="top" align="left" semx-id="_9e3b7c70-0b84-b484-c6e4-b59a454ed669"><tt>intdiv(a, b)</tt></td>
+<td id="_926fbb5c-f628-19ab-e2c9-1a27f768742c" valign="top" align="left" semx-id="_926fbb5c-f628-19ab-e2c9-1a27f768742c">a ÷ b, a and b are integers, result rounded towards zero</td>
+</tr><tr id="_87536bc5-96c4-c9ee-352c-e83219f9b0e4" semx-id="_87536bc5-96c4-c9ee-352c-e83219f9b0e4"><td id="_d4966f58-85f3-0412-c601-58e7a5876b84" valign="top" align="left" semx-id="_d4966f58-85f3-0412-c601-58e7a5876b84"><tt>modulus(a, b)</tt></td>
+<td id="_9715363c-666c-2cd5-29f0-ad00eed3c7f8" valign="top" align="left" semx-id="_9715363c-666c-2cd5-29f0-ad00eed3c7f8">remainder of a ÷ b, a and b are integers</td>
+</tr><tr id="_b83d525e-7582-a95e-d855-bdc5331d9966" semx-id="_b83d525e-7582-a95e-d855-bdc5331d9966"><td id="_6df35bee-9994-0926-848f-089601cef1f9" valign="top" align="left" semx-id="_6df35bee-9994-0926-848f-089601cef1f9"><tt>power(a, b)</tt></td>
+<td id="_ecea747b-04e5-47f9-e299-ce707eec990a" valign="top" align="left" semx-id="_ecea747b-04e5-47f9-e299-ce707eec990a">a<sup>b</sup></td>
+</tr></tbody>
+</table>
+
+<p id="_4d8462d0-ff97-2817-2920-f7713dbce61f" semx-id="_4d8462d0-ff97-2817-2920-f7713dbce61f">A parser may also permit user defined functions to be registered prior to parsing.</p>
+</clause>
+</clause>
+</clause>
+
+
+<references id="_651d9228-e1cb-940b-7deb-66306295d133" normative="true" obligation="informative" semx-id="_651d9228-e1cb-940b-7deb-66306295d133" displayorder="5">
+<title id="_8ae69d0c-5c6a-a873-7645-7424d3d1f80f" semx-id="_270c5ee6-077e-f285-ff95-287984a30140">Normative references</title><fmt-title depth="1" id="_e6fe1ae3-6f6b-c64d-79a1-29b41423c3c6"><span class="fmt-caption-label"><semx element="autonum" source="_651d9228-e1cb-940b-7deb-66306295d133">2</semx><span class="fmt-autonum-delim">.</span></span><span class="fmt-caption-delim"><tab/></span><semx element="title" source="_8ae69d0c-5c6a-a873-7645-7424d3d1f80f">Normative references</semx></fmt-title><fmt-xref-label><span class="fmt-element-name">Clause</span> <semx element="autonum" source="_651d9228-e1cb-940b-7deb-66306295d133">2</semx></fmt-xref-label><p id="_a6fdff30-00b4-3e56-d92a-a8d15322a761" semx-id="_a6fdff30-00b4-3e56-d92a-a8d15322a761">There are no normative references in this document.</p>
+
+<p id="_c5ee051a-0989-40ce-bbd4-ac9d4b1f62e3" semx-id="_c5ee051a-0989-40ce-bbd4-ac9d4b1f62e3">This document does not contain any normative references.</p>
+</references></sections><bibliography><references id="_a8a47ab3-e8e3-9657-87ab-40ddcd71ff9c" normative="false" obligation="informative" semx-id="_a8a47ab3-e8e3-9657-87ab-40ddcd71ff9c" displayorder="8">
+<title id="_79a2af9e-6853-19a3-fcb8-27eb8dad0c44" semx-id="_50ceb1e1-516f-2673-d73d-4f0c58b4d023">Bibliography</title><fmt-title depth="1" id="_2da55403-b11b-078e-f7e8-f49a7def2e71"><semx element="title" source="_79a2af9e-6853-19a3-fcb8-27eb8dad0c44">Bibliography</semx></fmt-title><bibitem anchor="RSASHARE" id="RSASHARE" semx-id="_52b888e9-7448-c2aa-298a-df5a2373e7b1"><biblio-tag>[1]<tab/></biblio-tag>
+  <formattedref format="application/x-isodoc+xml">Michael Malkin, Thomas D. Wu, Dan Boneh. <em>Experimenting with Shared Generation of RSA keys</em>. NDSS 1999.</formattedref><docidentifier type="metanorma-ordinal">[1]</docidentifier>
+  
+  <language>en</language>
+  <script>Latn</script>
+</bibitem>
+
+</references></bibliography>
+</metanorma>

--- a/spec/ribose_document_namespace_spec.rb
+++ b/spec/ribose_document_namespace_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe "Metanorma::Ribose::Document namespace" do
+  describe "canonical namespace" do
+    it "exposes Metanorma::Ribose::Document as a Module" do
+      expect(Metanorma::Ribose::Document).to be_a(Module)
+    end
+
+    it "exposes Root with the canonical name" do
+      expect(Metanorma::Ribose::Document::Root.name)
+        .to eq("Metanorma::Ribose::Document::Root")
+    end
+
+    it "Root is a lutaml Serializable" do
+      expect(Metanorma::Ribose::Document::Root < Lutaml::Model::Serializable).to be(true)
+    end
+  end
+
+  describe "backwards-compat alias" do
+    it "Metanorma::RiboseDocument aliases to the new namespace" do
+      expect(Metanorma::RiboseDocument).to eq(Metanorma::Ribose::Document)
+    end
+
+    it "the alias preserves class identity" do
+      expect(Metanorma::RiboseDocument::Root.equal?(
+               Metanorma::Ribose::Document::Root)).to be(true)
+    end
+  end
+
+  describe "parent namespace" do
+    it "Metanorma::Standoc::Document is available" do
+      expect(Metanorma::Standoc::Document).to be_a(Module)
+    end
+
+    it "Metanorma::StandardDocument alias is available" do
+      expect(Metanorma::StandardDocument).to eq(Metanorma::Standoc::Document)
+    end
+  end
+end

--- a/spec/ribose_roundtrip_spec.rb
+++ b/spec/ribose_roundtrip_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "bundler/setup"
+require "rspec/matchers"
+require "metanorma/ribose/document"
+require_relative "support/roundtrip_helper"
+require_relative "support/shared_roundtrip_examples"
+
+RSpec.describe "Ribose document XML round-trip" do
+  it_behaves_like "xml round-trip", flavor_dir: "ribose",
+                                    doc_class: Metanorma::Ribose::Document::Root
+end

--- a/spec/support/roundtrip_helper.rb
+++ b/spec/support/roundtrip_helper.rb
@@ -1,0 +1,190 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+
+module RoundtripHelper
+  FIXTURES_DIR = File.expand_path("../fixtures", __dir__)
+
+  # Discover all non-collection XML fixtures for a flavor directory.
+  # Returns Array<Hash> with :name, :path, :flavor_dir, :xml_type keys.
+  def self.discover_fixtures(flavor_dir: nil)
+    base = File.join(FIXTURES_DIR, flavor_dir)
+    Dir[File.join(base, "**", "*.xml")].filter_map do |path|
+      next if path.include?("/collection/")
+      next if collection_xml?(path)
+
+      name = build_name(path)
+      xml_type = path.end_with?(".presentation.xml") ? "presentation" : "semantic"
+
+      { name: name, path: path, flavor_dir: flavor_dir, xml_type: xml_type }
+    end
+  end
+
+  # Discover collection XML fixtures.
+  # Returns Array<Hash> with :name, :path, :xml_type keys.
+  def self.discover_collections(flavor_dir: nil)
+    base = File.join(FIXTURES_DIR, flavor_dir)
+    Dir[File.join(base, "collection", "collection*.xml")].map do |path|
+      name = File.basename(path, ".xml")
+      xml_type = path.end_with?(".presentation.xml") ? "presentation" : "semantic"
+
+      { name: name, path: path, xml_type: xml_type }
+    end
+  end
+
+  # Parse XML with Nokogiri, strip namespaces for consistent CSS selectors.
+  def self.parse_xml(xml_string)
+    doc = Nokogiri::XML(xml_string, &:noblanks)
+    doc.remove_namespaces!
+    doc
+  end
+
+  # Check for ERROR-level parse errors.
+  def self.xml_has_errors?(xml_string)
+    doc = Nokogiri::XML(xml_string)
+    doc.errors.any? { |e| e.type == Nokogiri::XML::SyntaxError::ERROR }
+  end
+
+  # Compute the read/parse/serialize/re-parse cycle ONCE per fixture for
+  # the whole suite. Roundtrip specs assert against these immutable
+  # artifacts; previously every example repeated the full cycle (up to
+  # 18 times per fixture — the dominant suite cost on multi-MB files).
+  def self.fixture_data(path, doc_class)
+    @fixture_data_cache ||= {}
+    @fixture_data_cache[[path, doc_class]] ||= begin
+      xml = File.read(path)
+      doc = doc_class.from_xml(xml)
+      output_xml = doc.to_xml
+      {
+        xml: xml,
+        doc: doc,
+        output_xml: output_xml,
+        original_noko: parse_xml(xml),
+        roundtrip_noko: parse_xml(output_xml),
+      }
+    end
+  end
+
+  # Extract root element attributes as a hash.
+  def self.root_attrs(doc)
+    root = doc.root
+    return {} unless root
+
+    { name: root.name, type: root["type"], flavor: root["flavor"],
+      version: root["version"] }
+  end
+
+  # Extract bibdata type attribute.
+  def self.bibdata_type(doc)
+    bibdata = doc.at_css("bibdata")
+    bibdata ? bibdata["type"] : nil
+  end
+
+  # Extract title elements as [language, type, text] triples.
+  def self.bibdata_titles(doc)
+    doc.css("bibdata > title").map do |t|
+      [t["language"], t["type"], t.text.strip]
+    end
+  end
+
+  # Extract status stage text.
+  def self.status_stage(doc)
+    doc.at_css("bibdata > status stage")&.text&.strip
+  end
+
+  # Extract top-level section clause IDs (sorted).
+  def self.section_clause_ids(doc)
+    doc.css("sections > clause").filter_map { |c| c["id"] }.sort
+  end
+
+  # Check if preface element exists.
+  def self.has_preface?(doc)
+    !doc.at_css("preface").nil?
+  end
+
+  # Extract annex IDs (sorted).
+  def self.annex_ids(doc)
+    doc.css("annex").filter_map { |a| a["id"] }.sort
+  end
+
+  # Count bibliography references sections.
+  def self.bibliography_references_count(doc)
+    doc.css("bibliography > references").length
+  end
+
+  # Extract bibliography normative attributes in order.
+  def self.bibliography_normative_attrs(doc)
+    doc.css("bibliography > references").map { |r| r["normative"] }
+  end
+
+  # Extract term IDs (sorted).
+  def self.term_ids(doc)
+    doc.css("term").filter_map { |t| t["id"] }.sort
+  end
+
+  # Extract table IDs (sorted).
+  def self.table_ids(doc)
+    doc.css("table").filter_map { |t| t["id"] }.sort
+  end
+
+  # Extract figure IDs (sorted).
+  def self.figure_ids(doc)
+    doc.css("figure").filter_map { |f| f["id"] }.sort
+  end
+
+  # Extract formula IDs (sorted).
+  def self.formula_ids(doc)
+    doc.css("formula").filter_map { |f| f["id"] }.sort
+  end
+
+  # Extract nested clause IDs — 2 levels deep (sorted).
+  def self.nested_clause_ids(doc)
+    doc.css("sections clause clause").filter_map { |c| c["id"] }.sort
+  end
+
+  # Count inline-header attributes.
+  def self.inline_header_count(doc)
+    doc.css("[inline-header]").length
+  end
+
+  # Collection-specific: count directive elements.
+  def self.collection_directive_count(doc)
+    doc.css("directive").length
+  end
+
+  # Collection-specific: count entry elements.
+  def self.collection_entry_count(doc)
+    doc.css("entry").length
+  end
+
+  # Collection-specific: count doc-container elements.
+  def self.doc_container_count(doc)
+    doc.css("doc-container").length
+  end
+
+  # Collection-specific: extract doc-container IDs.
+  def self.doc_container_ids(doc)
+    doc.css("doc-container").filter_map { |d| d["id"] }.sort
+  end
+
+  # Collection-specific: extract primary docidentifiers from embedded docs.
+  def self.doc_container_docidentifiers(doc)
+    doc.css("doc-container bibdata > docidentifier[primary]").map do |d|
+      d.text.strip
+    end.sort
+  end
+
+  class << self
+    private
+
+    def build_name(path)
+      rel = path.sub("#{FIXTURES_DIR}/", "")
+      rel.sub(/\.xml$/, "")
+    end
+
+    def collection_xml?(path)
+      content = File.read(path, 200)
+      content.include?("<metanorma-collection")
+    end
+  end
+end

--- a/spec/support/shared_roundtrip_examples.rb
+++ b/spec/support/shared_roundtrip_examples.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+
+require "nokogiri"
+
+# Shared examples for XML round-trip specs.
+# Use in spec files via:
+#   it_behaves_like "xml round-trip", flavor_dir: "ogc", doc_class: nil
+RSpec.shared_examples "xml round-trip" do |flavor_dir:, doc_class: nil, full: true|
+  fixtures = RoundtripHelper.discover_fixtures(flavor_dir: flavor_dir)
+
+  fixtures.each do |fixture|
+    describe fixture[:name] do
+      let(:data) { RoundtripHelper.fixture_data(fixture[:path], doc_class) }
+      let(:xml) { data[:xml] }
+      let(:doc) { data[:doc] }
+      let(:output_xml) { data[:output_xml] }
+      let(:original_noko) { data[:original_noko] }
+      let(:roundtrip_noko) { data[:roundtrip_noko] }
+
+      it "parses without error" do
+        expect(doc).to be_a(doc_class)
+      end
+
+      it "produces valid XML" do
+        expect(RoundtripHelper).not_to be_xml_has_errors(output_xml)
+      end
+
+      it "round-trips root element and attributes" do
+        expect(roundtrip_noko.root.name).to eq("metanorma")
+        expect(roundtrip_noko.root["type"]).to eq(original_noko.root["type"])
+        expect(roundtrip_noko.root["flavor"]).to eq(original_noko.root["flavor"])
+      end
+
+      it "round-trips bibdata type" do
+        expect(RoundtripHelper.bibdata_type(roundtrip_noko)).to eq(RoundtripHelper.bibdata_type(original_noko))
+      end
+
+      it "round-trips titles" do
+        expect(RoundtripHelper.bibdata_titles(roundtrip_noko)).to eq(RoundtripHelper.bibdata_titles(original_noko))
+      end
+
+      it "round-trips status stage" do
+        expect(RoundtripHelper.status_stage(roundtrip_noko)).to eq(RoundtripHelper.status_stage(original_noko))
+      end
+
+      it "round-trips section clause IDs" do
+        expect(RoundtripHelper.section_clause_ids(roundtrip_noko)).to eq(RoundtripHelper.section_clause_ids(original_noko))
+      end
+
+      it "round-trips preface" do
+        expect(RoundtripHelper.has_preface?(roundtrip_noko)).to eq(RoundtripHelper.has_preface?(original_noko))
+      end
+
+      it "round-trips annex IDs" do
+        expect(RoundtripHelper.annex_ids(roundtrip_noko)).to eq(RoundtripHelper.annex_ids(original_noko))
+      end
+
+      it "round-trips bibliography references sections" do
+        expect(RoundtripHelper.bibliography_references_count(roundtrip_noko)).to eq(RoundtripHelper.bibliography_references_count(original_noko))
+      end
+
+      it "round-trips bibliography normative attributes" do
+        expect(RoundtripHelper.bibliography_normative_attrs(roundtrip_noko)).to eq(RoundtripHelper.bibliography_normative_attrs(original_noko))
+      end
+
+      if full
+        it "round-trips term IDs" do
+          expect(RoundtripHelper.term_ids(roundtrip_noko)).to eq(RoundtripHelper.term_ids(original_noko))
+        end
+
+        it "round-trips table IDs" do
+          expect(RoundtripHelper.table_ids(roundtrip_noko)).to eq(RoundtripHelper.table_ids(original_noko))
+        end
+
+        it "round-trips figure IDs" do
+          expect(RoundtripHelper.figure_ids(roundtrip_noko)).to eq(RoundtripHelper.figure_ids(original_noko))
+        end
+
+        it "round-trips formula IDs" do
+          expect(RoundtripHelper.formula_ids(roundtrip_noko)).to eq(RoundtripHelper.formula_ids(original_noko))
+        end
+
+        it "round-trips nested clause structure" do
+          expect(RoundtripHelper.nested_clause_ids(roundtrip_noko)).to eq(RoundtripHelper.nested_clause_ids(original_noko))
+        end
+      end
+
+      if fixture[:xml_type] == "presentation"
+        it "preserves type=presentation on root" do
+          expect(roundtrip_noko.root["type"]).to eq("presentation")
+        end
+
+        if full
+          it "round-trips inline-header attributes" do
+            expect(RoundtripHelper.inline_header_count(roundtrip_noko)).to eq(RoundtripHelper.inline_header_count(original_noko))
+          end
+        end
+      end
+    end
+  end
+end
+
+RSpec.shared_examples "collection round-trip" do |flavor_dir:|
+  require "metanorma/collection"
+
+  collections = RoundtripHelper.discover_collections(flavor_dir: flavor_dir)
+
+  collections.each do |fixture|
+    describe fixture[:name] do
+      let(:data) do
+        RoundtripHelper.fixture_data(fixture[:path],
+                                     Metanorma::Collection::Root)
+      end
+      let(:xml) { data[:xml] }
+      let(:doc) { data[:doc] }
+      let(:output_xml) { data[:output_xml] }
+      let(:original_noko) { data[:original_noko] }
+      let(:roundtrip_noko) { data[:roundtrip_noko] }
+
+      it "parses without error" do
+        expect(doc).to be_a(Metanorma::Collection::Root)
+      end
+
+      it "produces valid XML" do
+        expect(RoundtripHelper).not_to be_xml_has_errors(output_xml)
+      end
+
+      it "round-trips root element name" do
+        expect(roundtrip_noko.root.name).to eq("metanorma-collection")
+      end
+
+      it "round-trips collection bibdata type" do
+        expect(RoundtripHelper.bibdata_type(roundtrip_noko)).to eq("collection")
+      end
+
+      it "round-trips collection title" do
+        orig_title = original_noko.at_css("bibdata > title")&.text&.strip
+        rt_title = roundtrip_noko.at_css("bibdata > title")&.text&.strip
+        expect(rt_title).to eq(orig_title)
+      end
+
+      it "round-trips collection docidentifier" do
+        orig_id = original_noko.at_css("bibdata > docidentifier")&.text&.strip
+        rt_id = roundtrip_noko.at_css("bibdata > docidentifier")&.text&.strip
+        expect(rt_id).to eq(orig_id)
+      end
+
+      it "round-trips directive count" do
+        expect(RoundtripHelper.collection_directive_count(roundtrip_noko)).to eq(
+          RoundtripHelper.collection_directive_count(original_noko),
+        )
+      end
+
+      it "round-trips entry count" do
+        expect(RoundtripHelper.collection_entry_count(roundtrip_noko)).to eq(
+          RoundtripHelper.collection_entry_count(original_noko),
+        )
+      end
+
+      it "round-trips doc-container count" do
+        expect(RoundtripHelper.doc_container_count(roundtrip_noko)).to eq(
+          RoundtripHelper.doc_container_count(original_noko),
+        )
+      end
+
+      it "round-trips doc-container IDs" do
+        expect(RoundtripHelper.doc_container_ids(roundtrip_noko)).to eq(
+          RoundtripHelper.doc_container_ids(original_noko),
+        )
+      end
+
+      it "round-trips embedded document docidentifiers" do
+        expect(RoundtripHelper.doc_container_docidentifiers(roundtrip_noko)).to eq(
+          RoundtripHelper.doc_container_docidentifiers(original_noko),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Metanorma::Generic::Document` is now the canonical name for the generic flavor document model. The model moved from `lib/metanorma/generic_document*` in metanorma-document to `lib/metanorma/generic/document*` in metanorma-generic, matching the `Metanorma::<Flavor>::Document::*` ecosystem pattern.

Part of the coordinated multi-PR Phase 4 migration tracked in metanorma-iso `TODO.validate/36-model-ownership-migration.md`:
- **metanorma/metanorma-standoc#1232** — StandardDocument → Standoc::Document
- **metanorma/metanorma-iso#1618** — IsoDocument → Iso::Document
- **metanorma/metanorma-document#45** — marks old autoloads as deprecated
- **This PR** — GenericDocument → Generic::Document
- (follow-up PRs for other flavors)

## Changes

- Copy `lib/metanorma/generic_document*` (2 files) from metanorma-document → `lib/metanorma/generic/document*` (byte-identical source).
- Rename namespace: `Metanorma::GenericDocument` → `Metanorma::Generic::Document`.
- File paths: `lib/metanorma/generic_document*` → `lib/metanorma/generic/document*`.
- Absolute refs: `Metanorma::StandardDocument::*` → `Metanorma::Standoc::Document::*`.
- Forward-declare `Metanorma::Generic` in `document.rb` for direct-require safety.
- Wire `lib/metanorma/generic.rb` to require `metanorma/generic/document`.
- Backwards-compat alias `Metanorma::GenericDocument = Metanorma::Generic::Document` via `deprecate_constant`.
- Cross-PR Gemfile branch pins so CI resolves the chain.
- Add `spec/generic_document_namespace_spec.rb` (8 examples).

## Test verification

Locally green:
- `bundle exec rspec spec/generic_document_namespace_spec.rb` — 8 examples, 0 failures

## Dependencies

Cross-PR Gemfile pins (CI fetches from GitHub):
- `metanorma-standoc` → `feat/move-standard-document` (PR #1232)
- `metanorma-document` → `feat/model-validation-l1-declarations` (PR #45)
- `isodoc`, `relaton-bib`, `pubid` to in-flight branches

All Gemfile pins revert to released gems once their respective PRs merge.

## Test plan

- [ ] CI passes
- [ ] `Metanorma::Generic::Document::Root.name` returns the new canonical name
- [ ] `Metanorma::GenericDocument` alias resolves to the new namespace
- [ ] `ruby -W -e 'require "metanorma/generic"; Metanorma::GenericDocument'` shows deprecation warning
