### PR TITLE
OCP adoption: model tree + core flavor table registration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}" }
 
 gemspec
 
+# TEMPORARY cross-PR pins (metanorma-core#18 wave)
+gem "metanorma-core", github: "metanorma/metanorma-core", branch: "feat/flavor-table"
+gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/move-standard-document"
+gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
+gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
+
 eval_gemfile("Gemfile.devel") rescue nil

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,13 @@ gem "metanorma-standoc", github: "metanorma/metanorma-standoc", branch: "feat/mo
 gem "metanorma-document", github: "metanorma/metanorma-document", branch: "feat/model-validation-l1-declarations"
 gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-validation-migration"
 
+# pubid-2 / relaton-bib 2.2 chain (isodoc PR#825)
+gem "isodoc",
+    github: "metanorma/isodoc",
+    branch: "rt-pubid-2-migration"
+gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
+gem "pubid",
+    github: "pubid/pubid",
+    branch: "main"
+
 eval_gemfile("Gemfile.devel") rescue nil

--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem "metanorma-iso", github: "metanorma/metanorma-iso", branch: "feat/model-vali
 gem "isodoc",
     github: "metanorma/isodoc",
     branch: "rt-pubid-2-migration"
+gem "relaton-cli", ">= 2.2.0.pre.alpha.1"
 gem "relaton-bib", "~> 2.2.0.pre.alpha.1"
 gem "pubid",
     github: "pubid/pubid",

--- a/lib/metanorma/ribose/document.rb
+++ b/lib/metanorma/ribose/document.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "metanorma/standoc"
+module Metanorma
+  module Ribose
+  end
+end
+
+module Metanorma
+  module Ribose::Document
+  end
+end
+
+module Metanorma
+  existing = defined?(Metanorma::RiboseDocument) && Metanorma::RiboseDocument
+  if !existing.equal?(Metanorma::Ribose::Document)
+    Metanorma.send(:remove_const, :RiboseDocument) if existing
+    RiboseDocument = Metanorma::Ribose::Document
+  end
+end
+
+# OCP adoption: ONE registration in the metanorma-core flavor table
+require "metanorma-core"
+
+Metanorma::Core::Flavors.register(Metanorma::Core::Flavor.new(
+  name: :ribose,
+  gem: "metanorma-ribose",
+  model_root: Metanorma::Ribose::Document::Root,
+  pubid_module: nil,
+  renderers: { html: Metanorma::Html::StandardRenderer },
+))

--- a/lib/metanorma/ribose/document/metadata.rb
+++ b/lib/metanorma/ribose/document/metadata.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ribose::Document
+    module Metadata
+      autoload :RiboseBibDataExtensionType,
+               "#{__dir__}/metadata/ribose_bib_data_extension_type"
+      autoload :RiboseBibliographicItem,
+               "#{__dir__}/metadata/ribose_bibliographic_item"
+    end
+  end
+end

--- a/lib/metanorma/ribose/document/metadata/ribose_bib_data_extension_type.rb
+++ b/lib/metanorma/ribose/document/metadata/ribose_bib_data_extension_type.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ribose::Document
+    module Metadata
+      # Extension point for bibliographical definitions of Ribose documents.
+      # Inherits all ISO extension fields; adds security and recipient.
+      class RiboseBibDataExtensionType < Metanorma::IsoDocument::Metadata::IsoBibDataExtensionType
+        attribute :security, :string
+        attribute :recipient, :string
+
+        xml do
+          element "ext"
+          map_element "security", to: :security
+          map_element "recipient", to: :recipient
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ribose/document/metadata/ribose_bibliographic_item.rb
+++ b/lib/metanorma/ribose/document/metadata/ribose_bibliographic_item.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ribose::Document
+    module Metadata
+      # Bibliographical description of a Ribose document.
+      # Inherits all ISO bibliographic fields; overrides ext for Ribose format.
+      class RiboseBibliographicItem < Metanorma::IsoDocument::Metadata::IsoBibliographicItem
+        attribute :ext, RiboseBibDataExtensionType
+
+        xml do
+          element "bibdata"
+          map_element "ext", to: :ext
+        end
+      end
+    end
+  end
+end

--- a/lib/metanorma/ribose/document/root.rb
+++ b/lib/metanorma/ribose/document/root.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Metanorma
+  module Ribose::Document
+    class Root < Lutaml::Model::Serializable
+      include Metanorma::StandardDocument::RootAttributes
+
+      attribute :bibdata,
+                Metanorma::Ribose::Document::Metadata::RiboseBibliographicItem
+      attribute :preface,
+                Metanorma::StandardDocument::Sections::Preface
+      attribute :sections,
+                Metanorma::StandardDocument::Sections::Sections
+      attribute :annex,
+                Metanorma::StandardDocument::Sections::AnnexSection,
+                collection: true
+
+      xml do
+        element "metanorma"
+        namespace Metanorma::StandardDocument::Namespace
+
+        Metanorma::StandardDocument::RootXmlMapping.apply(self)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Model tree extracted from metanorma-document@main and registered with the metanorma-core flavor table (metanorma-core#18). One entry: model_root, renderer, pubid. Part of the full-OCP restructure wave.